### PR TITLE
Fix MacOS serial build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@
 /src/pkg/re2temp/
 
 .*.swp
+
+*.dSYM

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,17 @@ ifeq "$(WS_LIB_DIR)" ""
 endif
 
 .PHONY: all install test uninstall clean
-all: 
+all:
 #	@export WS_HOME
+ifndef WS_PARALLEL
 	@echo "Building SERIAL waterslide"
 	@unset WS_PARALLEL ; $(MAKE) --no-print-directory -C src
+	$(LINK) bin/waterslide
+else
 	@echo "Building PARALLEL waterslide"
 	@WS_PARALLEL=1 $(MAKE) --no-print-directory -C src
-	$(LINK) bin/waterslide
 	$(LINK) bin/waterslide-parallel
+endif
 	$(LINK) bin/wsalias
 	$(LINK) bin/wsman
 
@@ -45,9 +48,9 @@ ifneq "$(DIR_ERROR)" "1"
 #	$(RM) -r $(WS_LIB_DIR)
 # don't delete the protobuf stuff; use "make scour" for that
 ifneq "$(wildcard $(WS_LIB_DIR))" ""
-	$(FIND) $(WS_LIB_DIR) -maxdepth 1 -type f -delete 
+	$(FIND) $(WS_LIB_DIR) -maxdepth 1 -type f -delete
 endif
-	$(RM) $(WS_BIN_DIR)/* $(WS_PROCS_DIR)/proc_*   
+	$(RM) $(WS_BIN_DIR)/* $(WS_PROCS_DIR)/proc_*
 	$(RM) -r $(RPM_OUTDIR)
 else
 	@echo "*** Error: problem with distribution directories"
@@ -55,7 +58,7 @@ endif
 
 .PHONY: scour
 scour: clean
-	-$(RM) -r $(WS_LIB_DIR) 
+	-$(RM) -r $(WS_LIB_DIR)
 
 
 DT := $(shell date -u +%Y%m%d.%H%M)
@@ -69,7 +72,7 @@ tar: scour
 	@cd .. && tar -cvjf $(BASEDISTRO)_$(DT).tar.bz2 $(BASEDISTRO)/. --exclude=".nfs*" > /dev/null
 	@du -h "$(DIRNAME)/$(BASEDISTRO)_$(DT).tar.bz2"
 
-tar_ng: scour 
+tar_ng: scour
 	@echo "Cleaning git repository"
 	@echo "Building ../$(BASEDISTRO)_$(DT)_nogit.tar.bz2"
 	@cd .. && tar -cvjf $(BASEDISTRO)_$(DT)_nogit.tar.bz2 $(BASEDISTRO)/. --exclude=.git* --exclude=*.nfs* --group=nobody --owner=nobody >/dev/null

--- a/procs/.wsalias
+++ b/procs/.wsalias
@@ -1,170 +1,83 @@
 addlabelmember: alm, addlabelm
-addlabelmember: alm, addlabelm
-appendfirstitem: appendfirst
 appendfirstitem: appendfirst
 appendlast: appendlastitem
-appendlast: appendlastitem
-asciihex: asciihex
 asciihex: asciihex
 bandwidth: bw
-bandwidth: bw
-base64: unbase64
 base64: unbase64
 bloom: bloomuniq
-bloom: bloomuniq
-bundle: bundle
 bundle: bundle
 calc: mathwscalc, math, icalc
-calc: mathwscalc, math, icalc
-charcnt: charcnt
 charcnt: charcnt
 cntquery: metacntquery, cntquery_shared, metacntquery_shared
-cntquery: metacntquery, cntquery_shared, metacntquery_shared
-combinestrings: combinestrings
 combinestrings: combinestrings
 countlabels: countlabels
-countlabels: countlabels
-csv_in: csv_in
 csv_in: csv_in
 data2label: data2label
-data2label: data2label
-decodejson: json, jsondecode
 decodejson: json, jsondecode
 denest: unnest, flatten
-denest: unnest, flatten
-dupestring: dupestring
 dupestring: dupestring
 dupetuple: dtuple, duptup, tupdup
-dupetuple: dtuple, duptup, tupdup
-encodebase64: encodebase64
 encodebase64: encodebase64
 equal: equal
-equal: equal
-exactmatch: ematch
 exactmatch: ematch
 exec_in: exec_in
-exec_in: exec_in
-file_in: file_in
 file_in: file_in
 fillmissing: fillmissing
-fillmissing: fillmissing
-firstn: first, firstn_shared, first_shared
 firstn: first, firstn_shared, first_shared
 fixedmatch: fmatch, fixedmatch_shared, fmatch_shared
-fixedmatch: fmatch, fixedmatch_shared, fmatch_shared
-flush: flush
 flush: flush
 haslabel: order
-haslabel: order
-heavyhitters: heavyhitters
 heavyhitters: heavyhitters
 jointuple: join, jointuples
-jointuple: join, jointuples
-keeplast: lastvalue
 keeplast: lastvalue
 keepn: keepn
-keepn: keepn
-keyadd: keyadd
 keyadd: keyadd
 keyadd_initial: keyadd_initial
-keyadd_initial: keyadd_initial
-keyadd_initial_custom: trackbkey, keyadd_initial_custom_shared, trackbkey_shared
 keyadd_initial_custom: trackbkey, keyadd_initial_custom_shared, trackbkey_shared
 keyaverage: avgkey
-keyaverage: avgkey
-keycount: countkey
 keycount: countkey
 keyflow: keyflow
-keyflow: keyflow
-keyrate: keyrate
 keyrate: keyrate
 keytime: keyoccur
-keytime: keyoccur
-keyvariance: varkey
 keyvariance: varkey
 label: labeler, metalabel, namer
-label: labeler, metalabel, namer
-labelmultiple: labelmultiple
 labelmultiple: labelmultiple
 labelstat: statlabel
-labelstat: statlabel
-lastn: appendlastn, lastn_shared, appendlastn_shared
 lastn: appendlastn, lastn_shared, appendlastn_shared
 loadbalance: loadbalance
-loadbalance: loadbalance
-match: stringmatch, aho
 match: stringmatch, aho
 match_uint: matchu, uintmatch, uintcmp, cmpuint
-match_uint: matchu, uintmatch, uintcmp, cmpuint
-mergetuple: mergetuple
 mergetuple: mergetuple
 metadice: metaout, metaprint, printmeta
-metadice: metaout, metaprint, printmeta
-mklabelset: mklabelset
 mklabelset: mklabelset
 mknest: renest
-mknest: renest
-print: pmeta, p
 print: pmeta, p
 print2json: pmetajson, pjson
-print2json: pmetajson, pjson
-rbsort: rbsort
 rbsort: rbsort
 re2: re2
-re2: re2
-redis: hiredis
-redis: hiredis
-removefromtuple: tupledelete, tupleremove
 removefromtuple: tupledelete, tupleremove
 sample: sample
-sample: sample
-sed: sed
 sed: sed
 sort: sort
-sort: sort
-source_keygen: source_keygen
 source_keygen: source_keygen
 splitstring: splitstring
-splitstring: splitstring
-splittuple: tsplit, tuplesplit
 splittuple: tsplit, tuplesplit
 stateclimb: stateclimb
-stateclimb: stateclimb
-strings: strings
 strings: strings
 strlen: strlen
-strlen: strlen
-substring: substring
 substring: substring
 subtuple: stuple, subtup, tupsub
-subtuple: stuple, subtup, tupsub
-tcpcatch: tcpcatch
 tcpcatch: tcpcatch
 tcpthrow: tcpthrow
-tcpthrow: tcpthrow
-top: top
 top: top
 tr: tr
-tr: tr
-tuplehash: hashtuple, tuplehasher, metatuplehash, thash
 tuplehash: hashtuple, tuplehasher, metatuplehash, thash
 udpgen_in: udpgen_in
-udpgen_in: udpgen_in
-udpgen_in_buf: udpgen_in_buf
 udpgen_in_buf: udpgen_in_buf
 unbundle: unbundle
-unbundle: unbundle
-uniq: unique, uniq_shared, unique_shared
 uniq: unique, uniq_shared, unique_shared
 uniqexpire: expireuniq
-uniqexpire: expireuniq
 untiln: until
-untiln: until
-workbalance: wbalance
-workreceive: wreceive
-writebuffer: writebuffer
 writebuffer: writebuffer
 wsproto_in: pb2in, pb2_filein
-wsproto_in: pb2in, pb2_filein
-wsproto_out: pb2out, pb2_fileout
 wsproto_out: pb2out, pb2_fileout

--- a/src/common.mk
+++ b/src/common.mk
@@ -1,7 +1,7 @@
 
 # General project Makefile contents
 
-# Build verbosity 
+# Build verbosity
 #   Define WS_VERBOSEBUILD for verbose build
 
 # As this file (common.mk) is stored at .../src,
@@ -68,9 +68,9 @@ ifdef USEM64
 endif
 
 WS_INCLUDE = -I$(WS_BUILDROOT)/include -I$(WS_BUILDROOT) -I.
-LDFLAGS += -L$(WS_LIB_DIR) 
+LDFLAGS += -L$(WS_LIB_DIR)
 
-LDFLAGS += -lm -lrt -lz -lpthread  
+LDFLAGS += -lm -lz -lpthread
 
 ifndef WSLIB
   WSLIB=$(INSTALL_TARGET)/lib
@@ -84,15 +84,16 @@ ifndef OSNAME
   OSNAME = $(word 1,$(shell uname))
   ifndef OSNAME
     OSNAME = "unknown"
-  endif 
+  endif
 endif
 
 # Handle BSD a little differently
 
 ifeq "$(OSNAME)" "FreeBSD"
   NODL=1
-  ISFREEBSD=1
+  ISBSD=1
   OSNAME=LINUX
+  ISBSD=1
 endif
 
 ifndef NODL
@@ -102,7 +103,15 @@ endif
 # Other options: "SunOS", "Linux", "CYGWIN_NT-5.0", "Darwin"
 
 ifeq "$(OSNAME)" "Darwin"
-  CFLAGS += -bundle -undefined dynamic_lookup
+  CFLAGS += -undefined dynamic_lookup
+  ISBSD=1
+  ISDARWIN=1
+  WHOLE_ARCHIVE=-all_load
+  NO_WHOLE_ARCHIVE=-noall_load
+else
+  WHOLE_ARCHIVE=--whole-archive
+  NO_WHOLE_ARCHIVE=--no-whole-archive
+  LDFLAGS += -lrt
 endif
 
 # Tools
@@ -114,15 +123,15 @@ LINK = $(QUIET)ln -s
 AR = $(QUIET)ar
 RM = $(QUIET)rm -f
 IF = $(QUIET)if
-ifdef ISFREEBSD
-RMDIR = -$(QUIET)rmdir 
+ifdef ISBSD
+RMDIR = -$(QUIET)rmdir
 else
 RMDIR = $(QUIET)rmdir --ignore-fail-on-non-empty
 endif
 MKDIR = $(QUIET)mkdir -p
 TAR = $(QUIET)tar
 CD = $(QUIET)cd
-CP = $(QUIET)cp 
+CP = $(QUIET)cp
 LINK = $(QUIET)ln -s -f
 TOUCH = $(QUIET)touch
 FIND = $(QUIET)find

--- a/src/datatypes/Makefile
+++ b/src/datatypes/Makefile
@@ -8,16 +8,16 @@ CFLAGS += $(PERF_FLAG)
 
 MODULES = $(patsubst %.c, %$(WS_SFX), $(wildcard wsdt_*.c))
 
-CFLAGS += -shared 
+CFLAGS += -shared
 
 #DESTDIR = $(WS_HOME)/datatypes/$(PDIR)
 DESTDIR = $(WS_LIB_DIR)
 
-#all: $(PDIR) $(MODULES) $(DESTDIR) 
-all: $(DESTDIR) $(MODULES) 
+#all: $(PDIR) $(MODULES) $(DESTDIR)
+all: $(DESTDIR) $(MODULES)
 
 #$(PDIR):
-#	$(MKDIR) $(PDIR) 
+#	$(MKDIR) $(PDIR)
 
 $(DESTDIR):
 	$(MKDIR) $(DESTDIR)
@@ -25,11 +25,12 @@ $(DESTDIR):
 %$(WS_SFX): %.c
 	$(SHOWFILE)
 	$(CC) $(CFLAGS) $< -o $@
-ifndef ISFREEBSD
+ifndef ISBSD
 	$(CP) -t $(DESTDIR) $@
 else
 	$(CP) $@ $(DESTDIR)
 endif
 
 clean:
-	$(RM) .*.swp *.dSYM ._* *_so 
+	$(RM) *.o .*.swp ._* *.8 *_so
+	$(RM) -r *.dSYM

--- a/src/include/shared/shared_queue.h
+++ b/src/include/shared/shared_queue.h
@@ -27,7 +27,7 @@ SOFTWARE.
 #include <stdlib.h>
 #include <stdint.h>
 #include <pthread.h>
-#if !defined(__FreeBSD__)
+#if !(defined(__FreeBSD__) || defined(__APPLE__))
 #include <malloc.h>
 #endif
 #include <assert.h>
@@ -111,8 +111,8 @@ CPP_OPEN
 #define INCR_CANT_STORE()
 #define INCR_IDLE()
 #define INCR_TOTAL_LENGTH()
-#define INCR_LENGTH() 
-#define DECR_LENGTH() 
+#define INCR_LENGTH()
+#define DECR_LENGTH()
 #define QTYPE_SWSR()
 #define QTYPE_MWSR()
 #define SQPERF_NRANK()
@@ -595,7 +595,7 @@ static inline int shared_queue_length(shared_queue_t * q) {
           return 0;
      }
 
-     int length; 
+     int length;
      pthread_mutex_lock(&q->mutex);
      length = q->length;
      pthread_mutex_unlock(&q->mutex);

--- a/src/include/waterslide.h
+++ b/src/include/waterslide.h
@@ -120,7 +120,7 @@ static inline char* get_executable_path(void)
 
 #else
      #warning "This platform needs work in get_executable_path(); WS_* environment variables must be manually configured."
-     char *tmp = calloc(1, sizeof(char));
+     char *tmp = (char *)calloc(1, sizeof(char));
      if (!tmp) {
           error_print("failed get_executable_path calloc of tmp");
           return NULL;
@@ -148,7 +148,7 @@ static inline void set_default_env(void)
 	       exit(1);
 	  }
 	  // chop off /bin/<executable>
-	  strncpy(wspath, dirname(dirname(exepath)), sizeof(wspath)-1);  
+	  strncpy(wspath, dirname(dirname(exepath)), sizeof(wspath)-1);
 	  wspath[sizeof(wspath)-1] = '\0';
 	  free(exepath);
      } else {
@@ -166,9 +166,9 @@ static inline void set_default_env(void)
           currenv[sizeof(currenv)-1] = '\0';
 	  if (strcmp(dirname(currenv), wspath)) {
 	       fprintf(stderr, "  non-default proc path: %s\n",getenv(ENV_WS_PROC_PATH));
-	  } 
+	  }
      }
-	  
+
      if (!getenv(ENV_WS_ALIAS_PATH)) {
           strncpy(string1, wspath, sizeof(string1)-1);
           string1[sizeof(string1)-1] = '\0';
@@ -179,20 +179,20 @@ static inline void set_default_env(void)
           currenv[sizeof(currenv)-1] = '\0';
 	  if (strcmp(dirname(currenv), wspath)) {
 	       fprintf(stderr, "  non-default alias path: %s\n",getenv(ENV_WS_ALIAS_PATH));
-	  } 
+	  }
      }
 
      if (!getenv(ENV_WS_DATATYPE_PATH)) {
           strncpy(string1, wspath, sizeof(string1)-1);
           string1[sizeof(string1)-1] = '\0';
-          strncat(string1, "/lib", sizeof(string1) - strlen(string1) - 1); 
+          strncat(string1, "/lib", sizeof(string1) - strlen(string1) - 1);
 	  setenv(ENV_WS_DATATYPE_PATH, string1, 0);
      } else {
           strncpy(currenv, getenv(ENV_WS_DATATYPE_PATH), sizeof(currenv)-1);
           currenv[sizeof(currenv)-1] = '\0';
 	  if (strcmp(dirname(currenv), wspath)) {
 	       fprintf(stderr, "  non-default datatype path: %s\n",getenv(ENV_WS_DATATYPE_PATH));
-	  } 
+	  }
      }
 
      if (!getenv(ENV_WS_CONFIG_PATH)) {
@@ -205,7 +205,7 @@ static inline void set_default_env(void)
           currenv[sizeof(currenv)-1] = '\0';
 	  if (strcmp(dirname(currenv), wspath)) {
 	       fprintf(stderr, "  non-default config path: %s\n",getenv(ENV_WS_CONFIG_PATH));
-	  } 
+	  }
      }
 }
 
@@ -284,11 +284,11 @@ int mimo_compile_graph_internal(mimo_t *);
 // the following is used to emit data as a source
 // use this function when you want to be allocated a data buffer
 // to copy your data into prior to emitting..
-void * mimo_emit_data_copy(mimo_source_t *); 
+void * mimo_emit_data_copy(mimo_source_t *);
 
 //run processing graph to completion based on emitting sources
 // source data must be emitted (if available)
-// prior to calling this function.. 
+// prior to calling this function..
 // you don't have to have all your sources emit data.. just some
 // so that the graph can do work.
 int mimo_run_graph(mimo_t*);
@@ -298,7 +298,7 @@ int mimo_run_exiting_graph(mimo_t*);
 /// call this after you call mimo_run_graph
 //  keep calling it until it returns NULL..
 //  since you may have several bits of output data collected at a given sink
-void * mimo_collect_data(mimo_sink_t *, char *); 
+void * mimo_collect_data(mimo_sink_t *, char *);
 
 //use the following to print out graph upon loading of file or command line
 void mimo_output_graphviz(mimo_t *, FILE *);
@@ -328,7 +328,7 @@ typedef struct _wskid_t {
 //------------------
 //defined in init.h
 //
-// list of a processing modules function pointers and attributes     
+// list of a processing modules function pointers and attributes
 // loaded from a .so file
 struct _ws_proc_module_t;
 typedef struct _ws_proc_module_t ws_proc_module_t;
@@ -394,7 +394,7 @@ static inline int wsdata_add_label(wsdata_t * data, wslabel_t * label) {
      if (!label) return 0;
      tmp = __sync_fetch_and_add(&data->writer_label_len, 1);
      if (__builtin_expect(tmp >= WSDATA_MAX_LABELS, 0)) {
-          (void) __sync_fetch_and_sub(&data->writer_label_len, 1); 
+          (void) __sync_fetch_and_sub(&data->writer_label_len, 1);
           return 0;
      }
      data->labels[tmp] = label;

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -24,14 +24,14 @@ MODULES = $(sort $(patsubst %.o, %$(SUFFIX).o, $(FILES)))
 
 all: $(MODULES) $(WSARCHIVEFILE)
 
-wsperf.c: 
+wsperf.c:
 	$(SHOWFILE)
 
 $(WSARCHIVEFILE): $(MODULES)
 	$(SHOWFILE)
 	$(RM) $(WSARCHIVEFILE)  # otherwise ar leaves old code in there
 	$(AR) rcs $@ $(MODULES)
-	$(CP) $@ $(WS_LIB_DIR) 
+	$(CP) $@ $(WS_LIB_DIR)
 
 graph.lex.cc: graph.l graph.tab.hh
 	$(SHOWFILE)
@@ -58,7 +58,8 @@ wscalc.tab.c wscalc.tab.h: wscalc.y $(WS_BUILDROOT)/include/wscalc.h
 	$(CPP) $(CPPFLAGS) -c $< -o $@
 
 clean:
-	$(RM) *.so .*.swp *.dSYM ._* *.o shared/*.o 
+	$(RM) *.o .*.swp ._* *.8 *_so
+	$(RM) -r *.dSYM
 	$(RM) parse_graph.* graph.lex* graph.tab* wscalc.c wscalc.tab* wscalc_int.c wscalc_int.tab.c wscalc_int.tab.h
 	$(RM) libwaterslide.dylib libwaterslide.a libwaterslide-parallel.a
 

--- a/src/procs/Makefile
+++ b/src/procs/Makefile
@@ -18,14 +18,14 @@ endif
 
 #CFLAGS += $(WS_INCLUDE) $(WS_DEFS)
 CFLAGS += -Wno-unknown-pragmas -Wno-strict-aliasing
-LDFLAGS += -shared 
+LDFLAGS += -shared
 
 MODULES = $(patsubst %.c, %$(WS_SFX), $(wildcard *.c))
 MODULES += $(patsubst %.cc, %$(WS_SFX), $(wildcard *.cc))
 
-all: $(WS_PROCS_DIR) $(MODULES) 
+all: $(WS_PROCS_DIR) $(MODULES)
 
-$(WS_PROCS_DIR): 
+$(WS_PROCS_DIR):
 	$(MKDIR) $(WS_PROCS_DIR)
 
 #********
@@ -33,18 +33,18 @@ $(WS_PROCS_DIR):
 proc_calc$(WS_SFX): proc_calc.c $(WS_BUILDROOT)/include/wscalc.h
 
 proc_tcpcatch$(WS_SFX): proc_tcpcatch.c $(WS_BUILDROOT)/include/tcp_rw.h
-	$(SHOWFILE) 
+	$(SHOWFILE)
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 	$(INSTALL) $@ $(WS_PROCS_DIR)
 
 proc_tcpthrow$(WS_SFX): proc_tcpthrow.c $(WS_BUILDROOT)/include/tcp_rw.h
-	$(SHOWFILE) 
+	$(SHOWFILE)
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 	$(INSTALL) $@ $(WS_PROCS_DIR)
 
 ifdef HASMAGIC
 proc_filemagic$(WS_SFX): proc_filemagic.c
-	$(SHOWFILE) 
+	$(SHOWFILE)
 	$(CC) $(CFLAGS) $< -o $@ -lmagic $(LDFLAGS)
 	$(INSTALL) $@ $(WS_PROCS_DIR)
 else
@@ -62,25 +62,25 @@ ifndef NOPB
     PBLIB+= -L$(PBDIR)/lib -lprotobuf-lite -pthread -lpthread
   endif
 
-protobuf/wsserial.pb.cc: 
+protobuf/wsserial.pb.cc:
 	$(QUIET)$(MAKE) --no-print-directory -C protobuf
 
 proc_wsproto_in$(WS_SFX):proc_wsproto_in.cc protobuf/wsserial.pb.cc protobuf/wsproto.pb.cc
-	$(SHOWFILE) 
+	$(SHOWFILE)
 	$(CPP) $(PBFLAGS) $(CPPFLAGS) $^ -o $@ $(PBLIB) $(LDFLAGS)
 	$(INSTALL) $@ $(WS_PROCS_DIR)
 proc_wsproto_out$(WS_SFX): proc_wsproto_out.cc protobuf/wsserial.pb.cc protobuf/wsproto.pb.cc
-	$(SHOWFILE) 
+	$(SHOWFILE)
 	$(CPP) $(PBFLAGS) $(CPPFLAGS) $^ -o $@ $(PBLIB) $(LDFLAGS)
 	$(INSTALL) $@ $(WS_PROCS_DIR)
 proc_lastn$(WS_SFX): proc_lastn.c protobuf/wsproto.pb.cc
-	$(SHOWFILE) 
+	$(SHOWFILE)
 	$(CPP) $(PBFLAGS) $(CPPFLAGS) $^ -o $@ $(PBLIB) $(LDFLAGS)
 	$(INSTALL) $@ $(WS_PROCS_DIR)
 
 else
 proc_lastn$(WS_SFX): proc_lastn.c
-	$(SHOWFILE) 
+	$(SHOWFILE)
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 	$(INSTALL) $@ $(WS_PROCS_DIR)
 proc_wsproto_in$(WS_SFX): proc_wsproto_in.cc
@@ -91,7 +91,7 @@ endif
 
 ifndef NORE2
 proc_re2$(WS_SFX): proc_re2.cc
-	$(SHOWFILE) 
+	$(SHOWFILE)
 	$(CPP) $(CPPFLAGS) -I$(RE2INCLUDE) $< -o $@ $(RE2LIB)/libre2.a $(LDFLAGS)
 	$(INSTALL) $@ $(WS_PROCS_DIR)
 else
@@ -113,11 +113,11 @@ endif
 
 ifdef HASRDKAFKA
 proc_kafka_in$(WS_SFX): proc_kafka_in.c
-	$(SHOWFILE) 
+	$(SHOWFILE)
 	$(CC) $(CFLAGS) $< -o $@ -lrdkafka $(LDFLAGS)
 	$(INSTALL) $@ $(WS_PROCS_DIR)
 proc_kafka_multi_in$(WS_SFX): proc_kafka_multi_in.c
-	$(SHOWFILE) 
+	$(SHOWFILE)
 	$(CC) $(CFLAGS) $< -o $@ -lrdkafka $(LDFLAGS)
 	$(INSTALL) $@ $(WS_PROCS_DIR)
 else
@@ -129,7 +129,7 @@ endif
 
 ifdef HASREDIS
 proc_redis$(WS_SFX): proc_redis.c
-	$(SHOWFILE) 
+	$(SHOWFILE)
 	$(CC) $(CFLAGS) $< -o $@ -lhiredis $(LDFLAGS)
 	$(INSTALL) $@ $(WS_PROCS_DIR)
 else
@@ -163,6 +163,7 @@ endif
 	$(INSTALL) $@ $(WS_PROCS_DIR)
 
 clean:
-	$(RM) *.o .*.swp *.dSYM ._* *.8 *_so 
+	$(RM) *.o .*.swp ._* *.8 *_so
+	$(RM) -r *.dSYM
 	$(QUIET)$(MAKE) --no-print-directory -C protobuf clean
 

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -1,5 +1,5 @@
 #
-# WS Utils 
+# WS Utils
 #
 
 include ../common.mk
@@ -14,14 +14,14 @@ all: $(UTILS)
 ifndef WS_PARALLEL
 waterslide: waterslide.c ../lib/libwaterslide.a
 	$(SHOWFILE)
-	$(CC) $(CFLAGS) $(PERF_FLAG) $< -o $@ -Wl,--whole-archive $(WS_LIB_DIR)/libwaterslide.a -Wl,--no-whole-archive $(LDFLAGS)
-ifndef ISFREEBSD
+	$(CC) $(CFLAGS) $(PERF_FLAG) $< -o $@ -Wl,$(WHOLE_ARCHIVE) $(WS_LIB_DIR)/libwaterslide.a -Wl,$(NO_WHOLE_ARCHIVE) $(LDFLAGS)
+ifndef ISBSD
 	$(CP) -t $(WS_BIN_DIR) $@
 else
   ifeq "$(WS_BIN_DIR)" ""
   $(error WS_BIN_DIR is empty...cannot copy into unspecified directory)
   endif
-	$(CP) $@ $(WS_BIN_DIR) 
+	$(CP) $@ $(WS_BIN_DIR)
 endif
 
 else
@@ -32,14 +32,14 @@ endif
 ifdef WS_PARALLEL
 waterslide-parallel: waterslide-parallel.c ../lib/libwaterslide-parallel.a $(HWLOC_LINK)
 	$(SHOWFILE)
-	$(CC) $(CFLAGS) $(PERF_FLAG) $< -o $@ -Wl,--whole-archive $(WS_LIB_DIR)/libwaterslide-parallel.a -Wl,--no-whole-archive $(LDFLAGS) $(HWLOC_LINK)
-ifndef ISFREEBSD
+	$(CC) $(CFLAGS) $(PERF_FLAG) $< -o $@ -Wl,$(WHOLE_ARCHIVE) $(WS_LIB_DIR)/libwaterslide-parallel.a -Wl,$(NO_WHOLE_ARCHIVE) $(LDFLAGS) $(HWLOC_LINK)
+ifndef ISBSD
 	$(CP) -t $(WS_BIN_DIR) $@
 else
   ifeq "$(WS_BIN_DIR)" ""
   $(error WS_BIN_DIR is empty...cannot copy into unspecified directory)
   endif
-	$(CP) $@ $(WS_BIN_DIR) 
+	$(CP) $@ $(WS_BIN_DIR)
 endif
 
 else
@@ -50,7 +50,7 @@ endif
 wsman: wsman.c wsman_color.h wsman_map.h wsman_util.h wsman_word_wrap.h
 	$(SHOWFILE)
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
-ifndef ISFREEBSD
+ifndef ISBSD
 	$(CP) -t $(WS_BIN_DIR) $@
 else
   ifeq "$(WS_BIN_DIR)" ""
@@ -62,14 +62,14 @@ endif
 %: %.c
 	$(SHOWFILE)
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
-ifndef ISFREEBSD
+ifndef ISBSD
 	$(CP) -t $(WS_BIN_DIR) $@
 else
   ifeq "$(WS_BIN_DIR)" ""
   $(error WS_BIN_DIR is empty...cannot copy into unspecified directory)
   endif
-	$(CP) $@ $(WS_BIN_DIR) 
+	$(CP) $@ $(WS_BIN_DIR)
 endif
 
 clean:
-	$(RM) *.o $(UTILS) 
+	$(RM) -r *.dSYM *.o $(UTILS)

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -72,4 +72,5 @@ else
 endif
 
 clean:
-	$(RM) -r *.dSYM *.o $(UTILS)
+	$(RM) *.o $(UTILS)
+	$(RM) -r *.dSYM


### PR DESCRIPTION
Fixes the main 'Makefile' to only build 'waterslide-parallel' when 'WS_PARALLEL' is defined.  Also, fixes several variable checks to ensure all BSD derivatives (to include Darwin/MacOS) are treated the same (defaulted to only treating FreeBSD differently).