### PR TITLE
BUGFIX - fixed proc_destroy calls when freeing memory on null sharelabels

### DIFF
--- a/src/procs/proc_appendfirstitem.c
+++ b/src/procs/proc_appendfirstitem.c
@@ -427,7 +427,9 @@ int proc_destroy(void * vinstance) {
      stringhash5_destroy(proc->last_table);
 
      //free dynamic allocations
-     free(proc->sharelabel);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_appendlast.c
+++ b/src/procs/proc_appendlast.c
@@ -338,7 +338,9 @@ int proc_destroy(void * vinstance) {
      stringhash5_scour_and_destroy(proc->last_table, last_destroy, proc);
 
      //free dynamic allocations
-     free(proc->sharelabel);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_cntquery.c
+++ b/src/procs/proc_cntquery.c
@@ -479,8 +479,12 @@ int proc_destroy(void * vinstance) {
      stringhash5_destroy(proc->cntquery_table);
 
      //free dynamic allocations
-     free(proc->sharelabel);
-     free(proc->outfile);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
+     if (proc->outfile) {
+          free(proc->outfile);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_exactmatch.c
+++ b/src/procs/proc_exactmatch.c
@@ -691,8 +691,12 @@ int proc_destroy(void * vinstance) {
      stringhash9a_destroy(proc->exactmatch_table);
 
      //free dynamic allocations
-     free(proc->sharelabel);
-     free(proc->dump_file);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
+     if (proc->dump_file) {
+          free(proc->dump_file);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_jointuple.c
+++ b/src/procs/proc_jointuple.c
@@ -584,8 +584,12 @@ int proc_destroy(void * vinstance) {
      stringhash5_scour_and_destroy(proc->port_table[RIGHT], last_destroy, proc);
 
      //free dynamic allocations
-     free(proc->sharelabel);
-     free(proc->sharelabel5);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
+     if (proc->sharelabel5) {
+          free(proc->sharelabel5);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_keeplast.c
+++ b/src/procs/proc_keeplast.c
@@ -361,7 +361,9 @@ int proc_destroy(void * vinstance) {
      stringhash5_destroy(proc->last_table);
 
      //free dynamic allocations
-     free(proc->sharelabel);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_keepn.c
+++ b/src/procs/proc_keepn.c
@@ -447,7 +447,9 @@ int proc_destroy(void * vinstance) {
      stringhash5_destroy(proc->last_table);
 
      //free dynamic allocations
-     free(proc->sharelabel);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_keyadd_initial_custom.c
+++ b/src/procs/proc_keyadd_initial_custom.c
@@ -539,8 +539,12 @@ int proc_destroy(void * vinstance) {
      }
 
      //free dynamic allocations
-     free(proc->sharelabel);
-     free(proc->sharelabel5);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
+     if (proc->sharelabel5) {
+          free(proc->sharelabel5);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_keyaverage.c
+++ b/src/procs/proc_keyaverage.c
@@ -360,7 +360,9 @@ int proc_destroy(void * vinstance) {
      stringhash5_destroy(proc->key_table);
 
      //free dynamic allocations
-     free(proc->sharelabel);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_keycount.c
+++ b/src/procs/proc_keycount.c
@@ -418,8 +418,12 @@ int proc_destroy(void * vinstance) {
      stringhash5_destroy(proc->key_table);
 
      //free dynamic allocations
-     free(proc->sharelabel);
-     free(proc->strlabel);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
+     if (proc->strlabel) {
+          free(proc->strlabel);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_keyflow.c
+++ b/src/procs/proc_keyflow.c
@@ -374,8 +374,12 @@ int proc_destroy(void * vinstance) {
      stringhash5_destroy(proc->key_table);
 
      //free dynamic allocations
-     free(proc->sharelabel);
-     free(proc->outfile);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
+     if (proc->outfile) {
+          free(proc->outfile);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_keytime.c
+++ b/src/procs/proc_keytime.c
@@ -490,10 +490,18 @@ int proc_destroy(void * vinstance) {
      stringhash9a_destroy(proc->old_table);
 
      //free dynamic allocations
-     free(proc->sharelabel5);
-     free(proc->sharelabel);
-     free(proc->outfile5);
-     free(proc->outfile);
+     if (proc->sharelabel5) {
+          free(proc->sharelabel5);
+     }
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
+     if (proc->outfile5) {
+          free(proc->outfile5);
+     }
+     if (proc->outfile) {
+          free(proc->outfile);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_keyvariance.c
+++ b/src/procs/proc_keyvariance.c
@@ -401,7 +401,9 @@ int proc_destroy(void * vinstance) {
      stringhash5_destroy(proc->key_table);
 
      //free dynamic allocations
-     free(proc->sharelabel);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_labelstat.c
+++ b/src/procs/proc_labelstat.c
@@ -468,8 +468,12 @@ int proc_destroy(void * vinstance) {
      stringhash5_destroy(proc->key_table);
 
      //free dynamic allocations
-     free(proc->sharelabel);
-     free(proc->outfile);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
+     if (proc->outfile) {
+          free(proc->outfile);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_lastn.c
+++ b/src/procs/proc_lastn.c
@@ -903,9 +903,15 @@ int proc_destroy(void * vinstance) {
      stringhash5_destroy(proc->last_table);
 
      //free dynamic allocations
-     free(proc->input_protobuf);
-     free(proc->sharelabel);
-     free(proc->outfile);
+     if (proc->input_protobuf) {
+          free(proc->input_protobuf);
+     }
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
+     if (proc->outfile) {
+          free(proc->outfile);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_mergetuple.c
+++ b/src/procs/proc_mergetuple.c
@@ -384,7 +384,9 @@ int proc_destroy(void * vinstance) {
      stringhash5_scour_and_destroy(proc->last_table, last_destroy, proc);
 
      //free dynamic allocations
-     free(proc->sharelabel);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
      free(proc);
 
      return 1;

--- a/src/procs/proc_stateclimb.c
+++ b/src/procs/proc_stateclimb.c
@@ -406,8 +406,12 @@ int proc_destroy(void * vinstance) {
      stringhash5_destroy(proc->key_table);
 
      //free dynamic allocations
-     free(proc->sharelabel);
-     free(proc->outfile);
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
+     if (proc->outfile) {
+          free(proc->outfile);
+     }
      free(proc);
 
      return 1;


### PR DESCRIPTION
proc_destroy function did not properly check for a null value on sharelabel pointers before attempting to free memory. 
impacts kids that support optional shared-memory hashtables.