### PR TITLE
added new processing kids:

### DIFF
--- a/src/include/wstuple_ip.h
+++ b/src/include/wstuple_ip.h
@@ -1,0 +1,64 @@
+#ifndef _WATERSLIDE_TUPLE_IP_H
+#define _WATERSLIDE_TUPLE_IP_H
+
+/*
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+   */
+
+#include <arpa/inet.h>
+#include <string.h>
+#include "waterslide.h"
+#include "datatypes/wsdt_tuple.h"
+#include "cppwrap.h"
+
+#ifdef __cplusplus
+CPP_OPEN
+#endif // __cplusplus
+
+static inline int tuple_add_ipv6(wsdata_t * tdata,
+                           void * ipbuf, wslabel_t* label) {
+     char out[INET6_ADDRSTRLEN];
+     const char* result = inet_ntop(AF_INET6, ipbuf, out, sizeof(out));
+     if (!result) {
+          return 0;
+     }
+     tuple_dupe_string(tdata, label, result, strlen(result));
+     return 1;
+}
+
+
+
+static inline int tuple_add_ipv4(wsdata_t * tdata,
+                           void * ipbuf, wslabel_t* label) {
+     char out[INET_ADDRSTRLEN];
+     const char* result = inet_ntop(AF_INET, ipbuf, out, sizeof(out));
+     if (!result) {
+          return 0;
+     }
+     tuple_dupe_string(tdata, label, result, strlen(result));
+     return 1;
+}
+
+#ifdef __cplusplus
+CPP_CLOSE
+#endif // __cplusplus
+
+#endif // _WATERSLIDE_TUPLE_IP_H
+

--- a/src/procs/Makefile
+++ b/src/procs/Makefile
@@ -54,6 +54,17 @@ proc_filemagic$(WS_SFX): proc_filemagic.c
 endif
 
 
+ifdef HASCRYPTO
+proc_hmac$(WS_SFX): proc_hmac.c
+	$(SHOWFILE) 
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS) -lcrypto
+	$(INSTALL) $@ $(WS_PROCS_DIR)
+else
+proc_hmac$(WS_SFX): proc_hmac.c
+	@echo " not building $@, set HASCRYPTO=1 to build"
+endif
+
+
 ifdef HASPCAP
 proc_pcapin$(WS_SFX): proc_pcapin.c
 	$(SHOWFILE) 

--- a/src/procs/Makefile
+++ b/src/procs/Makefile
@@ -53,6 +53,18 @@ proc_filemagic$(WS_SFX): proc_filemagic.c
 
 endif
 
+
+ifdef HASPCAP
+proc_pcapin$(WS_SFX): proc_pcapin.c
+	$(SHOWFILE) 
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS) -lpcap 
+	$(INSTALL) $@ $(WS_PROCS_DIR)
+else
+proc_pcapin$(WS_SFX): proc_pcapin.c
+	@echo " not building $@, set HASPCAP=1 to build"
+endif
+
+
 ifndef NOPB
   ifdef PBNONLOCAL
     PBFLAGS += -rdynamic -Wl,-rpath,`pkg-config protobuf --variable=libdir`

--- a/src/procs/proc_dns.c
+++ b/src/procs/proc_dns.c
@@ -1,0 +1,955 @@
+/*
+
+proc_dns.c - decode buffer containing binary DNS data
+
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+*/
+
+#define PROC_NAME "dns"
+//#define DEBUG 1
+#include <stdlib.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include "procloader_buffer.h"
+#include "wstuple_ip.h"
+
+int is_procbuffer = 1;
+int procbuffer_pass_not_found = 1;
+
+char proc_version[] = "1.0";
+char proc_requires[]     = "";
+const char *proc_tags[] = { "decode", "parse", NULL };
+char proc_name[] = PROC_NAME;
+char proc_purpose[] = "decode DNS data";
+const char *proc_synopsis[] = 
+     { "dns <LABEL OF DNS BUFFER> ", NULL };
+char proc_description[] = "decode a DNS payload\n"; 
+char *proc_alias[] = { NULL };
+
+proc_example_t proc_examples[]    = {
+     {NULL,""}
+};
+proc_option_t proc_opts[] = {
+     /*  'option character', "long option string", "option argument",
+      "option description", <allow multiple>, <required>*/
+     //the following must be left as-is to signify the end of the array
+     {'t',"","",
+     "process as TCP dns",0,0},
+     {'T',"","",
+     "process as TCP dns",0,0},
+     {' ',"","",
+     "",0,0}
+};
+
+char *proc_tuple_member_labels[] = {"DNS", NULL};
+char proc_nonswitch_opts[]    = "LABEL of tuple string member to decode as DNS";
+// proc_input_types and proc_output_types automatically set for procbuffer kids
+proc_port_t proc_input_ports[]     = {{NULL, NULL}};
+char *proc_tuple_container_labels[]     = {NULL};
+char *proc_tuple_conditional_container_labels[]   = {NULL};
+
+//function prototypes for local functions
+typedef struct _proc_instance_t {
+     wslabel_t * label_id;
+     wslabel_t * label_query;
+     wslabel_t * label_response;
+     wslabel_t * label_nx;
+     wslabel_t * label_opcode;
+     wslabel_t * label_qdcount;
+     wslabel_t * label_ancount;
+     wslabel_t * label_nscount;
+     wslabel_t * label_arcount;
+     wslabel_t * label_qrec;
+     wslabel_t * label_anrec;
+     wslabel_t * label_nsrec;
+     wslabel_t * label_arrec;
+     wslabel_t * label_aa;
+     wslabel_t * label_trunc;
+     wslabel_t * label_ipv4;
+     wslabel_t * label_rd;
+     wslabel_t * label_ra;
+     wslabel_t * label_z;
+     wslabel_t * label_rcode;
+     wslabel_t * label_type;
+     wslabel_t * label_class;
+     wslabel_t * label_name;
+     wslabel_t * label_ttl;
+     wslabel_t * label_rdata;
+     wslabel_t * label_a;
+     wslabel_t * label_ptr;
+     wslabel_t * label_aaaa;
+     wslabel_t * label_ns;
+     wslabel_t * label_cname;
+     wslabel_t * label_soa;
+     wslabel_t * label_mailbox;
+     wslabel_t * label_serial;
+     wslabel_t * label_refresh;
+     wslabel_t * label_retry;
+     wslabel_t * label_expire;
+     wslabel_t * label_minimum;
+     wslabel_t * label_txt;
+     wslabel_t * label_mx;
+     wslabel_t * label_mxpref;
+     wslabel_t * label_edns;
+     wslabel_t * label_payload;
+     wslabel_t * label_exrcode;
+     wslabel_t * label_version;
+     wslabel_t * label_dnssecok;
+     wslabel_t * label_option;
+     wslabel_t * label_optcode;
+     wslabel_t * label_optdata;
+     wslabel_t * label_caaflag;
+     wslabel_t * label_caatag;
+     wslabel_t * label_caavalue;
+     wslabel_t * label_caa;
+     wslabel_t * label_tcpdnslen;
+     wslabel_t * label_invalidtcpdns;
+     wslabel_t * label_invaliddns;
+     int tcpdns;
+
+} proc_instance_t;
+   
+int procbuffer_instance_size = sizeof(proc_instance_t);
+
+proc_labeloffset_t proc_labeloffset[] =
+{
+     {"QUERYID",offsetof(proc_instance_t, label_id)},
+     {"QUERY",offsetof(proc_instance_t, label_query)},
+     {"RESPONSE",offsetof(proc_instance_t, label_response)},
+     {"NX",offsetof(proc_instance_t, label_nx)},
+     {"OPCODE",offsetof(proc_instance_t, label_opcode)},
+     {"QCOUNT",offsetof(proc_instance_t, label_qdcount)},
+     {"ANCOUNT",offsetof(proc_instance_t, label_ancount)},
+     {"NSCOUNT",offsetof(proc_instance_t, label_nscount)},
+     {"ARCOUNT",offsetof(proc_instance_t, label_arcount)},
+     {"QUERY",offsetof(proc_instance_t, label_qrec)},
+     {"ANREC",offsetof(proc_instance_t, label_anrec)},
+     {"NSREC",offsetof(proc_instance_t, label_nsrec)},
+     {"ARREC",offsetof(proc_instance_t, label_arrec)},
+     {"AUTHANSWER",offsetof(proc_instance_t, label_aa)},
+     {"TRUNCATED",offsetof(proc_instance_t, label_trunc)},
+     {"RECURSIONDESIRED",offsetof(proc_instance_t, label_rd)},
+     {"RECURSIONAVAILABLE",offsetof(proc_instance_t, label_ra)},
+     {"Z",offsetof(proc_instance_t, label_z)},
+     {"RCODE",offsetof(proc_instance_t, label_rcode)},
+     {"TYPE",offsetof(proc_instance_t, label_type)},
+     {"CLASS",offsetof(proc_instance_t, label_class)},
+     {"NAME",offsetof(proc_instance_t, label_name)},
+     {"TTL",offsetof(proc_instance_t, label_ttl)},
+     {"RDATA",offsetof(proc_instance_t, label_rdata)},
+     {"A",offsetof(proc_instance_t, label_a)},
+     {"PTR",offsetof(proc_instance_t, label_ptr)},
+     {"AAAA",offsetof(proc_instance_t, label_aaaa)},
+     {"IPV4",offsetof(proc_instance_t, label_ipv4)},
+     {"NS",offsetof(proc_instance_t, label_ns)},
+     {"CNAME",offsetof(proc_instance_t, label_cname)},
+     {"SOA",offsetof(proc_instance_t, label_soa)},
+     {"MAILBOX",offsetof(proc_instance_t, label_mailbox)},
+     {"SERIAL",offsetof(proc_instance_t, label_serial)},
+     {"REFRESH",offsetof(proc_instance_t, label_refresh)},
+     {"RETRY",offsetof(proc_instance_t, label_retry)},
+     {"EXPIRE",offsetof(proc_instance_t, label_expire)},
+     {"MINIMUM",offsetof(proc_instance_t, label_minimum)},
+     {"TXT",offsetof(proc_instance_t, label_txt)},
+     {"MX",offsetof(proc_instance_t, label_mx)},
+     {"MXPREF",offsetof(proc_instance_t, label_mxpref)},
+     {"EDNS",offsetof(proc_instance_t, label_edns)},
+     {"PAYLOAD",offsetof(proc_instance_t, label_payload)},
+     {"EX_RCODE",offsetof(proc_instance_t, label_exrcode)},
+     {"VERSION",offsetof(proc_instance_t, label_version)},
+     {"DNSSEC_OK",offsetof(proc_instance_t, label_dnssecok)},
+     {"OPTION",offsetof(proc_instance_t, label_option)},
+     {"OPTCODE",offsetof(proc_instance_t, label_optcode)},
+     {"OPTDATA",offsetof(proc_instance_t, label_optdata)},
+     {"CAAFLAG",offsetof(proc_instance_t, label_caaflag)},
+     {"CAATAG",offsetof(proc_instance_t, label_caatag)},
+     {"CAAVALUE",offsetof(proc_instance_t, label_caavalue)},
+     {"CAA",offsetof(proc_instance_t, label_caa)},
+     {"TCPDNSLEN",offsetof(proc_instance_t, label_tcpdnslen)},
+     {"INVALIDTCPDNS",offsetof(proc_instance_t, label_invalidtcpdns)},
+     {"INVALIDDNS",offsetof(proc_instance_t, label_invaliddns)},
+     {"",0}
+};
+
+
+char procbuffer_option_str[]    = "tT";
+
+int procbuffer_option(void * vproc, void * type_table, int c, const char * str) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+
+     switch(c) {
+     case 't':
+     case 'T':
+          proc->tcpdns = 1;
+          break;
+     }
+     return 1;
+}
+
+typedef struct _dnsheader_t {
+     uint16_t id;
+   
+     //chunk1 
+     uint8_t code1;
+     uint8_t code2;
+     /*
+     uint8_t qr :1;
+     uint8_t opcode :4;
+     uint8_t aa:1;
+     uint8_t tc:1;
+     uint8_t rd:1;
+     
+     uint8_t ra:1;
+     uint8_t z:3;
+     uint8_t rcode:4;
+*/
+     uint16_t qdcount;
+     uint16_t ancount;
+     uint16_t nscount;
+     uint16_t arcount;
+} dnsheader_t;
+
+
+// return -1 on error, return 0 on empty, otherwise return length
+static int get_name_length(uint8_t * buf, int buflen, uint8_t * entire,
+                           int entirelen, int * roffset, int recursion_depth) {
+     if (recursion_depth > 3) {
+          dprint("too much recursion");
+          return -1;
+     }
+     int nlen = 0;
+     int offset = 0;
+     dprint("get name length, recursion:%d", recursion_depth);
+
+     while (offset < buflen) {
+          if (buf[offset] == 0) {
+               offset += 1;
+               break;
+          }
+          if (buf[offset] > 63) {
+               if (((buf[offset] & 0xC0) == 0xC0) && 
+                   ((offset + 1) < buflen)) {
+
+                    //its a pointer offeset
+                    uint16_t poffset = 
+                         (((uint16_t)buf[offset] & 0x3f) << 8) + (uint16_t)buf[offset + 1];
+                    if (poffset >= entirelen) {
+                         dprint("pointer offset exceeds length");
+                         return -1;
+                    }
+                    int plen = get_name_length(entire + poffset,
+                                               entirelen - poffset,
+                                               entire, entirelen,
+                                               roffset,
+                                               recursion_depth+1);
+                    if (plen < 0) {
+                         dprint("error from pointer return");
+                         return -1;
+                    }
+                    if (nlen) {  //if there is already partial length
+                         nlen += 1;
+                    }
+                    offset += 2;
+                    if (roffset) {
+                         *roffset = offset;
+                    }
+                    dprint("return from point check nlen %d plen %d", nlen, plen);
+                    return nlen + plen; // always return from pointer - it must be end of name
+               }
+               else {
+                    dprint("invalid length that is not an pointer %u",
+                           buf[offset]);
+                    return -1;
+               }
+          }
+          else {
+               //its a length
+               if ((buf[offset] + offset + 1) > buflen) {
+                    dprint("exceeded buffer");
+                    return -1;
+               }
+               if (nlen) {
+                    nlen += 1; //for period
+               }
+               nlen += buf[offset];
+               offset += buf[offset] + 1;
+          }
+     }
+
+     if (roffset) {
+          *roffset = offset;
+     }
+     return nlen;
+}
+
+//copy encoded dns name onto pre-allocated dest buffer
+//return 0 on error
+static int dupe_dns_name(wsdt_string_t * dest, int namelen, uint8_t * buf, int buflen,
+                         uint8_t * entire, int entirelen, int depth_buf_offset, int recursion_depth) {
+
+     int nlen = depth_buf_offset;  //offset of buffer already written
+     int offset = 0;
+
+     while (offset < buflen) {
+          if (buf[offset] == 0) {
+               break;
+          }
+          if (buf[offset] > 63) {
+               if (((buf[offset] & 0xC0) == 0xC0) && 
+                   ((offset + 1) < buflen)) {
+
+                    //its a pointer offeset
+                    uint16_t poffset = 
+                         (((uint16_t)buf[offset] & 0x3f) << 8) + (uint16_t)buf[offset + 1];
+                    if (poffset >= entirelen) {
+                         return 0;
+                    }
+                    return dupe_dns_name(dest, namelen, entire + poffset,
+                                         entirelen - poffset, entire, entirelen,
+                                         nlen, recursion_depth + 1);
+               }
+               else {
+                    dprint("invalid length");
+                    return 0;
+               }
+          }
+          else {
+               //its a length
+               if ((buf[offset] + offset + 1) > buflen) {
+                    dprint("exceeded buffer");
+                    return 0;
+               }
+               if (nlen >= namelen) {
+                    dprint("exceeded buffer");
+                    return 0;
+               }
+               if (nlen) {
+                    dest->buf[nlen] = '.';
+                    nlen += 1; //for period
+               }
+               if ((nlen + buf[offset]) > namelen) {
+                    dprint("exceeded dest buffer");
+                    return 0;
+               }
+               memcpy(dest->buf + nlen, buf + 1 + offset, buf[offset]); 
+               nlen += buf[offset];
+               offset += buf[offset] + 1;
+               dprint("dns output string so far: %.*s, len %d",
+                      nlen, dest->buf, nlen);
+          }
+     }
+
+     return nlen;
+}
+
+#define MIN_QREC (5)
+//returns offset after record processing
+static int process_query(proc_instance_t * proc, wsdata_t * tdata,
+                         wsdata_t * member, uint16_t qdcount,
+                         uint8_t * buf, int buflen,
+                         uint8_t * entire, int entirelen) {
+     uint16_t i;
+     int offset = 0;
+     int startoffset;
+
+     for (i = 0; i < qdcount; i++) {
+          if ((buflen - offset) < MIN_QREC) {
+               dprint("too small to be a qrec");
+               return 0; //too small to continue
+          }
+          startoffset = offset;
+          int newoffset = 0;
+          int nlen = get_name_length(buf + offset, buflen - offset, entire,
+                                     entirelen, &newoffset, 0);
+          dprint("returned get_name_length  nlen: %d, offset %d", nlen, offset);
+
+          if (nlen < 0) {
+               dprint("invalid name length");
+               return 0;
+          }
+          offset += newoffset;
+          if (offset >= buflen) {
+               dprint("query offset exceeded buffer");
+               return 0;
+          }
+
+          //getting ready to read codes:
+          if ((offset + 4) > buflen) {
+               dprint("buffer exceeded");
+               return 0;
+          }
+          uint16_t qtype = (buf[offset] <<8) + buf[offset+1];
+          uint16_t qclass = (buf[offset+2] <<8) + buf[offset+3];
+          offset += 4;
+
+          dprint("qtype %u, qclass %u", qtype, qclass);
+
+          wsdata_t * qrec = tuple_member_create_wsdata(tdata, dtype_tuple,
+                                                       proc->label_qrec);
+          if (qrec) {
+               tuple_member_create_uint16(qrec, qtype, proc->label_type);
+               tuple_member_create_uint16(qrec, qclass, proc->label_class);
+               if (!nlen) {
+                    char * nullstring = ".";
+                    tuple_dupe_string(qrec, proc->label_name, nullstring, 1);
+               }
+               else {
+                    wsdt_string_t * str = tuple_create_string(qrec,
+                                                              proc->label_name, nlen);
+                    if (str) {
+                         int dlen = dupe_dns_name(str, nlen, buf + startoffset,
+                                                  buflen - startoffset,
+                                                  entire, entirelen, 0, 0);
+                         if (dlen <= 0) {
+                              dprint("error getting dns name");
+                              str->len = 0;
+                         }
+                         if (dlen != nlen) {
+                              tool_print("unexpected length mismatch %d %d", dlen,
+                                     nlen);
+                         }
+                    }
+               }
+          }
+
+          //extract out name from startoffset
+
+     }
+
+     return offset;
+}
+
+//returns offset of name or 0 if error
+static int extract_rdname(wsdata_t * rrec,
+                          wslabel_t * label_name,
+                          uint8_t * rdbuf, int rdlen,
+                          uint8_t * entire, int entirelen) {
+     if (rdlen <= 0) {
+          dprint("invalid length %d", rdlen);
+          return 0;
+     }
+     int rdoffset = 0;
+     int namelen = get_name_length(rdbuf, rdlen, entire,
+                                   entirelen, &rdoffset, 0);
+     dprint("rd get_name_length  namelen: %d, rdoffset %d",
+            namelen, rdoffset);
+     if (namelen < 0) {
+          //invalid name
+          dprint("invalid ns name");
+          return 0;
+     }
+     if (namelen == 0) {
+          char * nullstring = ".";
+          tuple_dupe_string(rrec, label_name, nullstring, 1);
+     }
+     else {
+          wsdt_string_t * str = tuple_create_string(rrec,
+                                                    label_name,
+                                                    namelen);
+          int dupelen = 
+               dupe_dns_name(str, namelen, rdbuf, rdlen,
+                             entire, entirelen, 0, 0);
+          if (dupelen != namelen) {
+
+               tool_print("unexpected NS length mismatch %d %d",
+                          dupelen,
+                          namelen);
+          }
+     }
+     return rdoffset;
+}
+
+//return <=0 on error, otherwise returns length of edns record
+static int process_edns(proc_instance_t * proc, wsdata_t * tdata, wsdata_t *member,
+                        uint8_t * buf, int buflen,
+                        uint8_t * entire, int entirelen) {
+     int offset = 0;
+     dprint("process edns");
+     if (buflen < 10) {
+          dprint("invalid edns");
+          return 0;
+     }
+     uint16_t rtype = (buf[0] <<8) + buf[1];
+     if (rtype != 41) {
+          dprint("invalid edns rtype");
+          return 0;
+     }
+     uint16_t payload = (buf[2] <<8) + buf[3];  //payload size
+     uint8_t exrcode = buf[4];
+     uint8_t version = buf[5];
+     uint8_t dnssecok = buf[6] & 0x80;
+     uint16_t z = ((buf[6] & 0x7f)<<8) + buf[7];
+     uint16_t rdlen = (buf[8]<<8) + buf[9];
+     offset += 10;
+
+     wsdata_t * edns = tuple_member_create_wsdata(tdata, dtype_tuple, proc->label_edns);
+     if (!edns) {
+          return 0;
+     }
+     tuple_member_create_uint16(edns, payload, proc->label_payload);
+     tuple_member_create_uint16(edns, exrcode, proc->label_exrcode);
+     tuple_member_create_uint16(edns, version, proc->label_version);
+     if (dnssecok) {
+          tuple_add_member_label(tdata, edns, proc->label_dnssecok);
+     }
+     tuple_member_create_uint16(edns, z, proc->label_z);
+
+     dprint("edns rdlen %u", rdlen);
+
+     if ((rdlen + offset) > buflen) {
+          dprint("rdlen buffer exceeded");
+          return 0;
+     }
+     //do something with rd-data options
+     uint8_t * optbuf = buf + offset;
+     int optbuflen = rdlen;
+
+     while(optbuflen) {
+          dprint("printing edns option %d", optbuflen);
+          if (optbuflen < 4) {
+               dprint("invalid option lenght");
+               return 0;
+          }
+          uint16_t optcode = (optbuf[0] <<8) + optbuf[1];  
+          uint16_t optlen = (optbuf[2] <<8) + optbuf[3];  
+          dprint("optlen %u", optlen);
+
+          if (((int)optlen + 4) > optbuflen) {
+               dprint("invalid option lenght %d, %d", optlen, optbuflen);
+               return 0;
+          }
+          wsdata_t * opt = tuple_member_create_wsdata(edns, dtype_tuple,
+                                                      proc->label_option);
+          if (!opt) {
+               return 0;
+          }
+          tuple_member_create_uint16(opt, optcode, proc->label_optcode);
+
+          if (optlen) {
+               tuple_member_create_dep_binary(opt, member, proc->label_optdata,
+                                              (char *)(optbuf + 4), optlen);
+          }
+
+          optbuf += 4 + optlen;
+          optbuflen -= 4 + optlen;
+          dprint("optbuflen = %d", optbuflen);
+     }
+
+     offset += rdlen;
+     dprint("exited edns cleanly");
+     return offset;
+}
+ 
+
+#define MIN_RREC (11)
+//returns offset after record processing
+static int process_rrec(proc_instance_t * proc, wsdata_t * tdata, wsdata_t * member,
+                 int rcount, uint8_t * buf, int buflen,
+                 uint8_t * entire, int entirelen,
+                 wslabel_t * label_rec) {
+     dprint("process_rrec");
+     uint16_t i;
+     int offset = 0;
+     int startoffset;
+
+     for (i = 0; i < rcount; i++) {
+          if ((buflen - offset) < MIN_RREC) {
+               dprint("too small to be a rrec");
+               return 0; //too small to continue
+          }
+          //read name...
+          startoffset = offset;
+          int newoffset = 0;
+          int nlen = get_name_length(buf + offset, buflen - offset, entire,
+                                     entirelen, &newoffset, 0);
+          dprint("returned get_name_length  nlen: %d, offset %d", nlen, offset);
+
+          if (nlen < 0) {
+               dprint("invalid name length");
+               return 0;
+          }
+          offset += newoffset;
+          if (offset >= buflen) {
+               dprint("rrec offset exceeded buffer");
+               return 0;
+          }
+
+          //getting ready to read codes:
+          if ((offset + 10) > buflen) {
+               dprint("buffer exceeded");
+               return 0;
+          }
+          uint16_t rtype = (buf[offset] <<8) + buf[offset+1];
+
+
+          if ((rtype == 41) && (nlen == 0) && (newoffset == 1)) {
+               int edns_len = process_edns(proc, tdata, member,
+                                           buf + offset,
+                                           buflen - offset,
+                                           entire,
+                                           entirelen);
+               if (edns_len <= 0) {
+                    return 0;
+               }
+               offset = offset + edns_len;
+               continue; // loop to next record
+          }
+
+          uint16_t rclass = (buf[offset+2] <<8) + buf[offset+3];
+          uint32_t ttl =
+               (buf[offset+4]<<24) + (buf[offset+5]<<16) +
+               (buf[offset+6]<<8) + (buf[offset+7]);
+          uint16_t rdlen = (buf[offset+8]<<8) + buf[offset+9];
+          offset += 10;
+
+          if ((rdlen + offset) > buflen) {
+               dprint("rdlen buffer exceeded");
+               return 0;
+          }
+          uint8_t * rdbuf = buf + offset;
+          offset += rdlen;
+
+          dprint("rtype %u, rclass %u", rtype, rclass);
+
+          wsdata_t * rrec = tuple_member_create_wsdata(tdata, dtype_tuple,
+                                                       label_rec);
+          if (rrec) {
+               tuple_member_create_uint16(rrec, rtype, proc->label_type);
+               tuple_member_create_uint16(rrec, rclass, proc->label_class);
+               tuple_member_create_uint(rrec, ttl, proc->label_ttl);
+               if (!nlen) {
+                    char * nullstring = ".";
+                    tuple_dupe_string(rrec, proc->label_name, nullstring, 1);
+               }
+               else {
+                    wsdt_string_t * str = tuple_create_string(rrec,
+                                                              proc->label_name, nlen);
+                    if (str) {
+                         int dlen = dupe_dns_name(str, nlen, buf + startoffset,
+                                                  buflen - startoffset,
+                                                  entire, entirelen, 0, 0);
+                         if (dlen <= 0) {
+                              dprint("error getting dns name");
+                              str->len = 0;
+                         }
+                         if (dlen != nlen) {
+                              tool_print("unexpected length mismatch %d %d", dlen,
+                                     nlen);
+                         }
+                    }
+               }
+               switch(rtype) {
+               case 1: //  IPv4 address
+                    if (rdlen == 4) {
+                         tuple_add_member_label(tdata, rrec, proc->label_a);
+                         tuple_add_ipv4(rrec, rdbuf, proc->label_a);
+                    }
+                    break;
+               case 28: //  IPv4 address
+                    if (rdlen == 16) {
+                         tuple_add_member_label(tdata, rrec, proc->label_aaaa);
+                         tuple_add_ipv6(rrec, rdbuf, proc->label_aaaa);
+                    }
+                    break;
+
+               case 2:  //NS
+                    tuple_add_member_label(tdata, rrec, proc->label_ns);
+                    extract_rdname(rrec, proc->label_ns,
+                                   rdbuf, rdlen, entire, entirelen);
+                    break;
+               case 5: //cname
+                    tuple_add_member_label(tdata, rrec, proc->label_cname);
+                    extract_rdname(rrec, proc->label_cname,
+                                   rdbuf, rdlen, entire, entirelen);
+                    break;
+               case 12: //ptr
+                    tuple_add_member_label(tdata, rrec, proc->label_ptr);
+                    extract_rdname(rrec, proc->label_ptr,
+                                   rdbuf, rdlen, entire, entirelen);
+                    break;
+               case 16: //txt
+                    if (extract_rdname(rrec, proc->label_txt,
+                                   rdbuf, rdlen, entire, entirelen) <= 0) {
+                         //if name decoding fails -- try binary buffer
+                         if (rdlen) {
+                              tuple_member_create_dep_binary(rrec, member,
+                                                             proc->label_txt,
+                                                             (char *)rdbuf, rdlen);
+                         }
+                    }
+                    break;
+               case 257: //CAA
+                    if (rdlen < 2) {
+                         break;
+                    }
+                    tuple_add_member_label(tdata, rrec, proc->label_caa);
+                    tuple_member_create_uint16(rrec, rdbuf[0], proc->label_caaflag);
+                    uint8_t caalen = rdbuf[1];
+                    if (((int)caalen +2) > rdlen) {
+                         break;
+                    }
+                    tuple_member_create_dep_string(rrec, member,
+                                                   proc->label_caatag,
+                                                   (char *)(rdbuf + 2), caalen);
+                    uint8_t * remainder = rdbuf + 2 + caalen;
+                    int remainderlen = rdlen - 2 - caalen;
+
+                    if (remainderlen) {
+                         tuple_member_create_dep_string(rrec, member,
+                                                        proc->label_caavalue,
+                                                        (char *)(remainder),
+                                                        remainderlen);
+                    }
+                    break;
+               case 15: //MX
+                    {
+                         tuple_add_member_label(tdata, rrec, proc->label_mx);
+                         if (rdlen < 3) {
+                              break;
+                         }
+                         uint16_t mxpref = (rdbuf[0]<<8) + rdbuf[1];
+                         tuple_member_create_uint16(rrec, mxpref,
+                                                    proc->label_mxpref);
+                         rdbuf+=2;
+                         rdlen-=2;
+                         extract_rdname(rrec, proc->label_mx,
+                                        rdbuf, rdlen, entire, entirelen);
+                    break;
+                    }
+               case 6: //SOA
+                    {
+                         tuple_add_member_label(tdata, rrec, proc->label_soa);
+                         int nameoffset = extract_rdname(rrec, proc->label_soa,
+                                                         rdbuf, rdlen, entire, entirelen);
+                         if (nameoffset <= 0) {
+                              break;
+                         }
+                         if (nameoffset >= rdlen) {
+                              break;
+                         }
+                         rdbuf += nameoffset;
+                         rdlen -= nameoffset;
+                         nameoffset = extract_rdname(rrec, proc->label_mailbox,
+                                                     rdbuf, rdlen, entire, entirelen);
+                         if (nameoffset <= 0) {
+                              break;
+                         }
+                         if (nameoffset >= rdlen) {
+                              break;
+                         }
+                         rdbuf += nameoffset;
+                         rdlen -= nameoffset;
+
+                         if (rdlen != 20) {
+                              dprint("unusual soa length %d", rdlen);
+                              break;
+                         }
+                         uint32_t serial = ntohl(*(uint32_t*)(rdbuf + 0));
+                         uint32_t refresh = ntohl(*(uint32_t*)(rdbuf + 4));
+                         uint32_t retry = ntohl(*(uint32_t*)(rdbuf + 8));
+                         uint32_t expire = ntohl(*(uint32_t*)(rdbuf + 12));
+                         uint32_t minimum = ntohl(*(uint32_t*)(rdbuf + 16));
+                         tuple_member_create_uint(rrec, serial, proc->label_serial);
+                         tuple_member_create_uint(rrec, refresh, proc->label_refresh);
+                         tuple_member_create_uint(rrec, retry, proc->label_retry);
+                         tuple_member_create_uint(rrec, expire,
+                                                  proc->label_expire);
+                         tuple_member_create_uint(rrec, minimum,
+                                                  proc->label_minimum);
+                         break;
+                    }
+               default:
+                    if (rdlen) {
+                         tuple_member_create_dep_binary(rrec, member, proc->label_rdata,
+                                                        (char *)rdbuf, rdlen);
+                    }
+               }
+          }
+
+     }
+
+     return offset;
+}
+
+int procbuffer_decode(void * vproc, wsdata_t * tdata,
+                      wsdata_t * member, uint8_t * buf, int buflen) {
+     proc_instance_t * proc = (proc_instance_t*)vproc;
+
+     if (proc->tcpdns) {
+          if (buflen < 2) {
+               wsdata_add_label(tdata, proc->label_invalidtcpdns);
+               return 1;
+          }
+          uint16_t tcpbuflen = (buf[0]<<8) + buf[1];
+          tuple_member_create_uint16(tdata, tcpbuflen, proc->label_tcpdnslen);
+          if (buflen + 2 < tcpbuflen) {
+               wsdata_add_label(tdata, proc->label_invalidtcpdns);
+               dprint("truncated dns");
+          }
+          //force offset
+          buflen-=2;
+          buf+=2;
+     }
+
+     if (buflen < sizeof(dnsheader_t)) {
+          dprint("invalid header");
+          wsdata_add_label(tdata, proc->label_invaliddns);
+          return 1;
+     }
+     dnsheader_t * dhead = (dnsheader_t *)buf;
+
+
+     tuple_member_create_uint16(tdata, ntohs(dhead->id), proc->label_id);
+     dprint("bits:  %02x %02x, %02x %02x", dhead->code1, dhead->code2, buf[2], buf[3]);
+
+     uint8_t qr = (dhead->code1 >> 7) & 0x1;
+     uint8_t opcode = (dhead->code1 >> 3) & 0xF;
+     uint8_t aa = (dhead->code1 >> 2) & 0x1;
+     uint8_t tc = (dhead->code1 >> 1) & 0x1;
+     uint8_t rd = dhead->code1 & 0x1;
+     uint8_t ra = (dhead->code2 >> 7) & 0x1;
+     uint8_t z = (dhead->code2 >> 4) & 0x7;
+     uint8_t rcode = dhead->code2 & 0xF;
+
+     if (qr == 0) {
+          wsdata_add_label(tdata, proc->label_query);
+     }
+     else {
+          wsdata_add_label(tdata, proc->label_response);
+     }
+
+     dprint("decode %x %04x %x %x %x %x %03x %04x", qr, opcode, aa,
+            tc, rd, ra, z, rcode);
+
+     tuple_member_create_uint16(tdata, opcode, proc->label_opcode);
+                                
+     if (aa) {
+          wsdata_add_label(tdata, proc->label_aa);
+     }
+     if (tc) {
+          wsdata_add_label(tdata, proc->label_trunc);
+     }
+     if (rd) {
+          wsdata_add_label(tdata, proc->label_rd);
+     }
+     if (ra) {
+          wsdata_add_label(tdata, proc->label_ra);
+     }
+     if (z) {
+          tuple_member_create_uint16(tdata, z, proc->label_z);
+     }
+     if (rcode) {
+          wsdata_t * rcd = tuple_member_create_uint16(tdata, rcode, proc->label_rcode);
+          if (rcode == 3) {
+               wsdata_add_label(tdata, proc->label_nx);
+               tuple_add_member_label(tdata, rcd, proc->label_nx);
+          }
+     }
+
+     uint16_t qdcount = ntohs(dhead->qdcount);
+     uint16_t ancount = ntohs(dhead->ancount);
+     uint16_t nscount = ntohs(dhead->nscount);
+     uint16_t arcount = ntohs(dhead->arcount);
+
+
+     //TODO - check if counts are sane
+     int recmin = ((int)qdcount * MIN_QREC) + 
+          (((int)ancount + (int)nscount + (int)arcount) * MIN_RREC);
+
+     //prepare rrec processing
+     uint8_t * remain = buf + sizeof(dnsheader_t);
+     int remainlen = buflen - sizeof(dnsheader_t);
+
+     if (remainlen < recmin) {
+          wsdata_add_label(tdata, proc->label_invaliddns);
+          //truncated record detection..
+          return 1;
+     }
+
+     tuple_member_create_uint16(tdata, qdcount, proc->label_qdcount);
+     tuple_member_create_uint16(tdata, ancount, proc->label_ancount);
+     tuple_member_create_uint16(tdata, nscount, proc->label_nscount);
+     tuple_member_create_uint16(tdata, arcount, proc->label_arcount);
+
+     //now start processing queries and resource records..
+
+   
+     int rlen = 0; 
+     if (qdcount) {
+          rlen = process_query(proc, tdata, member, qdcount, remain,
+                                   remainlen, buf, buflen);
+          if (rlen <= 0) { 
+               dprint("exit early from process_query");
+               return 1;
+          }
+          if (rlen >= remainlen) {
+               return 1;
+          }
+          remain += rlen;
+          remainlen -= rlen;
+     }
+     
+     if (ancount) {
+          rlen = process_rrec(proc, tdata, member, ancount, remain, remainlen, buf,
+                              buflen, proc->label_anrec);
+          if (rlen <= 0) { 
+               dprint("exit early from anrec process_rrec");
+               return 1;
+          }
+          if (rlen >= remainlen) {
+               return 1;
+          }
+          remain += rlen;
+          remainlen -= rlen;
+     }
+     if (nscount) {
+          rlen = process_rrec(proc, tdata, member, nscount, remain, remainlen, buf,
+                              buflen, proc->label_nsrec);
+          if (rlen <= 0) { 
+               dprint("exit early from nsrec process_rrec");
+               return 1;
+          }
+          if (rlen >= remainlen) {
+               return 1;
+          }
+          remain += rlen;
+          remainlen -= rlen;
+     }
+     if (arcount) {
+          rlen = process_rrec(proc, tdata, member, arcount, remain, remainlen, buf,
+                              buflen, proc->label_arrec);
+          if (rlen <= 0) { 
+               dprint("exit early from arrec process_rrec");
+               return 1;
+          }
+          if (rlen >= remainlen) {
+               return 1;
+          }
+          remain += rlen;
+          remainlen -= rlen;
+     }
+          
+     return 1;
+}
+

--- a/src/procs/proc_duplicates.c
+++ b/src/procs/proc_duplicates.c
@@ -1,0 +1,234 @@
+/*
+
+proc_duplicates.c
+
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+*/
+#define PROC_NAME "duplicates"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "waterslide.h"
+#include "waterslidedata.h"
+#include "procloader.h"
+#include "evahash64.h"
+#include "evahash64_data.h"
+#include "stringhash9a.h"
+#include "datatypes/wsdt_tuple.h"
+
+char proc_version[]     = "1.5";
+char *proc_tags[]	= {"annotation", NULL};
+char *proc_menus[]     = { "Annotate", NULL };
+char *proc_alias[]     = { "dupes", "duplicate", "innerdupe", "innerdupes", "tupledupes", NULL};
+char proc_name[]       = PROC_NAME;
+char proc_purpose[]    = "Find and label duplicate tuple members";
+char proc_description[] = "Scans specified tuple members and labels any duplicate values.";
+char proc_requires[] = "none";
+
+
+proc_option_t proc_opts[] = {
+     /*  'option character', "long option string", "option argument",
+	 "option description", <allow multiple>, <required>*/
+     {'L',"","LABEL",
+     "label to apply to duplicate member",0,0},
+     {'U',"","LABEL",
+     "label to apply to unique member",0,0},
+     //the following must be left as-is to signify the end of the array
+     {' ',"","",
+     "",0,0}
+};
+char proc_nonswitch_opts[]    = "LABEL of member to check";
+char *proc_input_types[]    = {"any", NULL};
+char *proc_output_types[]    = {"any", NULL};
+proc_port_t proc_input_ports[] = {{NULL, NULL}};
+
+char *proc_tuple_container_labels[] = {NULL};
+char *proc_tuple_conditional_container_labels[] = {NULL};
+char *proc_tuple_member_labels[] = {NULL};
+
+#define LOCAL_MAX_TYPES 25
+
+//function prototypes for local functions
+static int proc_process_tuple(void *, wsdata_t*, ws_doutput_t*, int);
+
+typedef struct _proc_instance_t {
+     uint64_t meta_process_cnt;
+     uint64_t outcnt;
+
+     stringhash9a_t * dupe_table;
+     ws_outtype_t * outtype_tuple;
+     wslabel_nested_set_t nest;
+     wslabel_t * label_dupe;
+     wslabel_t * label_uniq;
+} proc_instance_t;
+
+static int proc_cmd_options(int argc, char ** argv, 
+                            proc_instance_t * proc, void * type_table) {
+     int op;
+
+     while ((op = getopt(argc, argv, "D:L:U:u:")) != EOF) {
+          switch (op) {
+          case 'u':
+          case 'U':
+               proc->label_uniq = wsregister_label(type_table, optarg);
+          break;
+          case 'D':
+          case 'L':
+               proc->label_dupe = wsregister_label(type_table, optarg);
+          break;
+          default:
+               return 0;
+          }
+     }
+     while (optind < argc) {
+          wslabel_nested_search_build(type_table, &proc->nest, argv[optind]);
+          tool_print("scanning element %s", argv[optind]);
+          optind++;
+     }
+
+     return 1;
+}
+#define DUPE_TABLE_SIZE 50000
+
+// the following is a function to take in command arguments and initalize
+// this processor's instance..
+//  also register as a source here..
+// return 1 if ok
+// return 0 if fail
+int proc_init(wskid_t * kid, int argc, char ** argv, void ** vinstance, ws_sourcev_t * sv,
+              void * type_table) {
+     
+     //allocate proc instance of this processor
+     proc_instance_t * proc =
+          (proc_instance_t*)calloc(1,sizeof(proc_instance_t));
+     *vinstance = proc;
+
+     proc->label_dupe = wsregister_label(type_table, "DUPLICATE");
+
+     //read in command options
+     if (!proc_cmd_options(argc, argv, proc, type_table)) {
+          return 0;
+     }
+
+     proc->dupe_table = stringhash9a_create(0, DUPE_TABLE_SIZE);
+     if (!proc->dupe_table) {
+          tool_print("unable to create a stringhash9a table");
+          return 0;
+     }
+
+    
+     if (!proc->nest.cnt) {
+          error_print("need to specify label to seach for");
+          return 0;
+     } 
+
+     return 1; 
+}
+
+// this function needs to decide on processing function based on datatype
+// given.. also set output types as needed (unless a sink)
+//return 1 if ok
+// return 0 if problem
+proc_process_t proc_input_set(void * vinstance, wsdatatype_t * meta_type,
+                              wslabel_t * port,
+                              ws_outlist_t* olist, int type_index,
+                              void * type_table) {
+     proc_instance_t * proc = (proc_instance_t *)vinstance;
+
+     if (wsdatatype_match(type_table, meta_type, "TUPLE_TYPE")) {
+          proc->outtype_tuple = ws_add_outtype(olist, meta_type, NULL);
+          return proc_process_tuple;
+     }
+     return NULL;
+}
+
+//callback when searching nested tuple
+static int proc_nest_match_callback(void * vproc, void * vehash,
+                                    wsdata_t * tdata, wsdata_t * member) {
+     proc_instance_t * proc = (proc_instance_t*)vproc;
+     uint64_t * p_ehash = (uint64_t *)vehash;
+     uint64_t ehash = *p_ehash;
+
+     if (member->dtype == dtype_tuple) {
+          return 0;
+     }
+
+     //xor data member hash with event hash - for unique hash per tuple
+     uint64_t datahash = evahash64_data(member, 1141533479) ^ ehash;
+
+     int found = stringhash9a_set(proc->dupe_table, &datahash, sizeof(uint64_t));
+
+     if (found) {
+          if (!wsdata_check_label(member, proc->label_dupe)) {
+               tuple_add_member_label(tdata, member, proc->label_dupe);
+          }
+     }
+     else if (proc->label_uniq) {
+          if (!wsdata_check_label(member, proc->label_uniq)) {
+               tuple_add_member_label(tdata, member, proc->label_uniq);
+          }
+     }
+
+     return 1;
+}
+
+static int proc_process_tuple(void * vinstance, wsdata_t* input_data,
+                        ws_doutput_t * dout, int type_index) {
+
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+
+     proc->meta_process_cnt++;
+
+     //create a per-event hash
+     uint64_t ehash = evahash64((uint8_t*)&proc->meta_process_cnt,
+                                sizeof(uint64_t),
+                                0x534fd);
+
+     //search for specified tuple member
+     tuple_nested_search(input_data, &proc->nest,
+                         proc_nest_match_callback,
+                         proc, &ehash);
+
+
+     // this is new data.. pass as output
+     ws_set_outdata(input_data, proc->outtype_tuple, dout);
+     proc->outcnt++;
+     return 1;
+}
+
+//return 1 if successful
+//return 0 if no..
+int proc_destroy(void * vinstance) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     tool_print("meta_proc cnt %" PRIu64, proc->meta_process_cnt);
+     tool_print("output cnt %" PRIu64, proc->outcnt);
+
+     if (proc->dupe_table) {
+          stringhash9a_destroy(proc->dupe_table);
+     }
+
+     //free dynamic allocations
+     free(proc);
+
+     return 1;
+}
+

--- a/src/procs/proc_grouppackets.c
+++ b/src/procs/proc_grouppackets.c
@@ -1,0 +1,485 @@
+/*
+
+proc_grouppackets.c -- group content carrying packets around the same session key
+
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+ */
+
+#define PROC_NAME "grouppackets"
+//#define DEBUG 1
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+//#include <netinet/tcp.h>
+#include "waterslide.h"
+#include "waterslidedata.h"
+#include "datatypes/wsdt_tuple.h"
+#include "stringhash5.h"
+#include "procloader.h"
+
+//defines from netinet/tcp.h
+# define TH_FIN     0x01
+# define TH_SYN     0x02
+# define TH_RST     0x04
+# define TH_PUSH    0x08
+# define TH_ACK     0x10
+# define TH_URG     0x20
+
+char proc_name[]               =  PROC_NAME;
+char proc_version[]            =  "1.5";
+char *proc_tags[]              =  {"Sessionization", "State tracking", NULL};
+char *proc_alias[]             =  { NULL };
+char proc_purpose[]            =  "group packets of the same TCP flow and direction";
+char proc_description[] = "attempts to partially sessionize TCP packets";
+
+proc_option_t proc_opts[]      =  {
+     /*  'option character', "long option string", "option argument",
+	 "option description", <allow multiple>, <required>*/
+     {'J',"","sharename",
+     "shared table with other kids",0,0},
+     {'f',"","",
+     "keep first n elements at key",0,0},
+     {'c',"","",
+     "emit count of stored elements",0,0},
+     {'n',"","count",
+     "number of each member to store at key",0,0},
+     {'N',"","count",
+     "emit only when count reaches limit",0,0},
+     {'V',"","label",
+     "label of member to store at key (can be multiple)",0,0},
+     {'M',"","records",
+     "maximum table size",0,0},
+     //the following must be left as-is to signify the end of the array
+     {' ',"","",
+     "",0,0}
+};
+
+char proc_nonswitch_opts[]     =  "LABEL of key to index on";
+char *proc_input_types[]       =  {"any","tuple", NULL};
+// (Potential) Output types: tuple
+char *proc_output_types[]      =  {"tuple", NULL};
+char proc_requires[]           =  "";
+// Ports: 
+proc_port_t proc_input_ports[] =  {
+     {"none","Store value at key"},
+     {NULL, NULL}
+};
+char *proc_tuple_container_labels[] =  {NULL};
+char *proc_tuple_conditional_container_labels[] =  {NULL};
+char *proc_tuple_member_labels[] =  {"KEEPCOUNT", NULL};
+char *proc_synopsis[]          =  {"grouppackets <LABEL>", NULL};
+proc_example_t proc_examples[] =  {
+	{NULL, NULL}
+};
+
+typedef struct _key_data_t {
+     uint32_t nextseq;
+     uint32_t ack;  //should be fixed
+     uint32_t contentcnt;
+     uint32_t contentlen;  //sum length of stored content buffers
+     wsdata_t * reference;  //first tuple member of this set
+     wsdata_t * content[0]; //content buffers to glue together
+} key_data_t;
+
+//function prototypes for local functions
+static int proc_tuple(void *, wsdata_t*, ws_doutput_t*, int);
+static int proc_flush(void *, wsdata_t*, ws_doutput_t*, int);
+
+typedef struct _proc_instance_t {
+     uint64_t meta_process_cnt;
+     uint64_t outcnt;
+
+     stringhash5_t * session_table;
+     uint32_t buflen;
+     wslabel_t * label_flow;
+     wslabel_t * label_seq;
+     wslabel_t * label_ack;
+     wslabel_t * label_content;
+     wslabel_t * label_session;
+     wslabel_t * label_packetcount;
+     wslabel_t * label_flags;
+     ws_outtype_t * outtype_tuple;
+     ws_doutput_t * dout;
+     int cnt;
+     size_t key_struct_size;
+
+     char * sharelabel;
+} proc_instance_t;
+
+static int proc_cmd_options(int argc, char ** argv, 
+                            proc_instance_t * proc, void * type_table) {
+     int op;
+
+     while ((op = getopt(argc, argv, "J:n:M:")) != EOF) {
+          switch (op) {
+          case 'J':
+               proc->sharelabel = strdup(optarg);
+               break;
+          case 'n':
+               proc->cnt = atoi(optarg);
+               tool_print("storing %d objects at key", proc->cnt);
+               if(proc->cnt <= 0) {
+                    error_print("invalid count of objects ... specified %d", proc->cnt);
+                    return 0;
+               }
+               break;
+          case 'M':
+               proc->buflen = atoi(optarg);
+               break;
+          default:
+               return 0;
+          }
+     }
+     while (optind < argc) {
+          proc->label_flow = wssearch_label(type_table, argv[optind]);
+          tool_print("using key %s", argv[optind]);
+          optind++;
+     }
+     
+     return 1;
+}
+
+
+static void emit_state(void * vdata, void * vproc) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+     key_data_t * kdata = (key_data_t *)vdata;
+     uint32_t i;
+     dprint("emit state");
+
+     if (!kdata->reference) {
+          return;
+     }
+
+     if (kdata->contentcnt == 1) {
+          dprint("single content");
+          tuple_member_add_ptr(kdata->reference, kdata->content[0],
+                               proc->label_session);
+
+          tuple_member_create_uint(kdata->reference, 1, proc->label_packetcount);
+          ws_set_outdata(kdata->reference, proc->outtype_tuple,
+                         proc->dout);
+          wsdata_delete(kdata->reference);
+     }
+     else {
+          dprint("merge content");
+          size_t offset = 0;
+          wsdt_binary_t * bin = 
+               tuple_create_binary(kdata->reference, proc->label_session,
+                                   kdata->contentlen);
+          if (!bin) {
+               wsdata_delete(kdata->reference);
+          }
+          else {
+               char * buffer;
+               int len;
+               for (i = 0; i < kdata->contentcnt; i++) {
+                    if (dtype_string_buffer(kdata->content[i],&buffer, &len) && 
+                        ((offset + len) <= bin->len)) {
+                         memcpy(bin->buf + offset, buffer, len);
+                         offset += len;
+                    }
+               }
+               if (offset != bin->len) {
+                    dprint("unexpected output length %d %d", (int)offset,
+                           bin->len);
+               }
+
+               tuple_member_create_uint(kdata->reference, kdata->contentcnt, proc->label_packetcount);
+               //output
+               ws_set_outdata(kdata->reference, proc->outtype_tuple,
+                              proc->dout);
+               wsdata_delete(kdata->reference);
+          }
+     }
+
+     dprint("clean up key_data");
+     //flush all stored content
+     for (i = 0; i < kdata->contentcnt; i++) {
+          wsdata_delete(kdata->content[i]);
+     }
+
+     memset(kdata, 0, proc->key_struct_size);
+}
+
+// the following is a function to take in command arguments and initalize
+// this processor's instance..
+//  also register as a source here..
+// return 1 if ok
+// return 0 if fail
+int proc_init(wskid_t * kid, int argc, char ** argv, void ** vinstance, ws_sourcev_t * sv,
+              void * type_table) {
+     
+     //allocate proc instance of this processor
+     proc_instance_t * proc =
+          (proc_instance_t*)calloc(1,sizeof(proc_instance_t));
+     *vinstance = proc;
+
+     ws_default_statestore(&proc->buflen);
+
+     proc->cnt = 10;
+     proc->label_session = wsregister_label(type_table, "SESSION");
+     proc->label_packetcount = wsregister_label(type_table, "PACKETCOUNT");
+
+     proc->label_flow = wssearch_label(type_table, "BIFLOW");
+     proc->label_seq = wssearch_label(type_table, "TCPSEQ");
+     proc->label_ack = wssearch_label(type_table, "TCPACK");
+     proc->label_content = wssearch_label(type_table, "CONTENT");
+     proc->label_flags = wssearch_label(type_table, "FLAGS");
+
+     //read in command options
+     if (!proc_cmd_options(argc, argv, proc, type_table)) {
+          return 0;
+     }
+
+     if (proc->cnt <= 1) {
+          tool_print("invalid session count");
+          return 0;
+     }
+
+     proc->key_struct_size = sizeof(key_data_t) + sizeof(wsdata_t*) * proc->cnt;
+
+     //other init - init the stringhash table
+     if (proc->sharelabel) {
+          // Note:  the following seems backwards.  But, if hitemit is set, we only
+          // want full sets of elements, so rec_erase is used to throw away all of 
+          // the partials at expire time.  But, if hitemit is not set, then we are
+          // expecting the partials, hence the use of emit_state here.
+          stringhash5_sh_opts_t * sh5_sh_opts;
+          int ret;
+
+          //calloc shared sh5 option struct
+          stringhash5_sh_opts_alloc(&sh5_sh_opts);
+
+          //set shared sh5 option fields
+          sh5_sh_opts->sh_callback = emit_state;
+          sh5_sh_opts->proc = proc; 
+
+          ret = stringhash5_create_shared_sht(type_table, (void **)&proc->session_table, 
+                                              proc->sharelabel, proc->buflen, 
+                                              proc->key_struct_size, 
+                                              NULL, sh5_sh_opts);
+
+          //free shared sh5 option struct
+          stringhash5_sh_opts_free(sh5_sh_opts);
+
+          if (!ret) return 0;
+     }
+     else {
+          proc->session_table = stringhash5_create(0, proc->buflen,
+                                                   proc->key_struct_size);
+          if (!proc->session_table) {
+               return 0;
+          }
+          stringhash5_set_callback(proc->session_table, emit_state, proc);
+     }
+
+     //use the stringhash5-adjusted value of max_records to reset buflen
+     proc->buflen = proc->session_table->max_records;
+
+     return 1; 
+}
+
+// this function needs to decide on processing function based on datatype
+// given.. also set output types as needed (unless a sink)
+//return 1 if ok
+// return 0 if problem
+proc_process_t proc_input_set(void * vinstance, wsdatatype_t * meta_type,
+                              wslabel_t * port,
+                              ws_outlist_t* olist, int type_index,
+                              void * type_table) {
+     proc_instance_t * proc = (proc_instance_t *)vinstance;
+
+     if (wsdatatype_match(type_table, meta_type, "FLUSH_TYPE")) {
+          proc->outtype_tuple = ws_add_outtype(olist, wsdatatype_get(type_table,
+                                                                     "TUPLE_TYPE"), NULL);
+          return proc_flush;
+     }
+     if (wsdatatype_match(type_table, meta_type, "TUPLE_TYPE")) {
+          proc->outtype_tuple = ws_add_outtype(olist, meta_type, NULL);
+          return proc_tuple;
+     }
+
+     return NULL; // a function pointer
+}
+
+static void check_for_flush(proc_instance_t * proc, key_data_t * kdata,
+                            uint32_t seqnum, uint32_t acknum, int contentlen) {
+
+     dprint("check for flush");
+     if ((kdata->ack == acknum) && (kdata->nextseq == seqnum)) {
+          dprint("seq number match");
+          return;
+     }
+     if (contentlen) {
+          dprint("added content emit %u %u %u %u", seqnum, kdata->nextseq,
+                     acknum, kdata->ack);
+          emit_state(kdata, proc);
+     }
+}
+
+
+//// proc processing function assigned to a specific data type in proc_io_init
+//return 1 if output is available
+// return 0 if not output
+static int proc_tuple(void * vinstance, wsdata_t* input_data,
+                        ws_doutput_t * dout, int type_index) {
+
+     dprint("proc_tuple");
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     proc->dout = dout;
+     proc->meta_process_cnt++;
+
+     //get FLOW KEY
+     wsdata_t ** mset;
+     int mset_len;
+     dprint("find key");
+     if (!tuple_find_label(input_data, proc->label_flow,
+                          &mset_len, &mset)) {
+          return 0;
+     }
+     wsdata_t * key = mset[0];
+
+     //get SEQ number
+     dprint("find seq");
+     if (!tuple_find_label(input_data, proc->label_seq,
+                          &mset_len, &mset)) {
+          return 0;
+     }
+     wsdata_t * seq = mset[0];
+     uint32_t seqnum = 0;
+     if (!seq->dtype->to_uint32 || !seq->dtype->to_uint32(seq, &seqnum)) {
+          return 0;
+     }
+
+     //get ACK number
+     dprint("find ack");
+     if (!tuple_find_label(input_data, proc->label_ack,
+                          &mset_len, &mset)) {
+          return 0;
+     }
+     wsdata_t * ack = mset[0];
+     uint32_t acknum;
+     if (!ack->dtype->to_uint32 || !ack->dtype->to_uint32(ack, &acknum)) {
+          return 0;
+     }
+
+     dprint("find flags");
+     if (!tuple_find_label(input_data, proc->label_flags,
+                          &mset_len, &mset)) {
+          return 0;
+     }
+     wsdata_t * flags = mset[0];
+     uint32_t flagval;
+     if (!flags->dtype->to_uint32 || !flags->dtype->to_uint32(flags, &flagval)) {
+          return 0;
+     }
+
+     key_data_t * kdata = 
+          (key_data_t *) stringhash5_find_attach_wsdata(proc->session_table, key);
+
+     if (!kdata) {
+          return 0;
+     }
+
+
+     int contentlen = 0;
+     wsdata_t * content = NULL;
+     dprint("find content");
+     if (tuple_find_label(input_data, proc->label_content,
+                          &mset_len, &mset)) {
+          content = mset[0];
+          char * buffer = NULL;
+          dtype_string_buffer(content, &buffer, &contentlen);
+     }
+
+     dprint("we have seq %u %u, content len %u, nextseq %u", seqnum, acknum,
+                contentlen, seqnum + (uint32_t)contentlen);
+     check_for_flush(proc, kdata, seqnum, acknum, contentlen); 
+     
+     if (!contentlen) {
+          dprint("no content");
+          if ((flagval & (TH_FIN || TH_SYN)) != 0) {
+               dprint("FYN emit %u %u", seqnum, acknum);
+               emit_state(kdata, proc);
+          }
+          return 0;
+     } 
+
+
+     dprint("adding content to keydata");
+     if (!kdata->reference) {
+          dprint("new reference");
+          kdata->reference = input_data;
+          wsdata_add_reference(input_data);
+     }
+     kdata->nextseq = seqnum + contentlen;
+     dprint("looking for seq %u %u", kdata->nextseq, acknum);
+     dprint("adding nextseq = %u", kdata->nextseq);
+     kdata->ack = acknum;
+     kdata->content[kdata->contentcnt] = content;
+     wsdata_add_reference(content);
+     kdata->contentlen += contentlen;
+     kdata->contentcnt++;
+     dprint("content added. cnt %u, len %u", kdata->contentcnt,
+            kdata->contentlen);
+
+     if ((kdata->contentcnt >= proc->cnt) ||
+         ((flagval & TH_FIN) != 0)) {
+          emit_state(kdata, proc);
+     }
+
+     //always return 1 since we don't know if table will flush old data
+     return 1;
+}
+
+static int proc_flush(void * vinstance, wsdata_t* input_data,
+                        ws_doutput_t * dout, int type_index) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     proc->dout = dout;
+
+     // Note:  the following seems backwards.  But, if hitemit is set, we only
+     // want full sets of elements, so rec_erase is used to throw away all of 
+     // the partials at flush time.  But, if hitemit is not set, then we are
+     // expecting the partials, hence the use of emit_state here.
+     stringhash5_scour_and_flush(proc->session_table, emit_state, proc);
+
+     return 1;
+}
+
+//return 1 if successful
+//return 0 if no..
+int proc_destroy(void * vinstance) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     tool_print("meta_proc cnt %" PRIu64, proc->meta_process_cnt);
+     tool_print("output cnt %" PRIu64, proc->outcnt);
+
+     //destroy table
+     stringhash5_destroy(proc->session_table);
+
+     //free dynamic allocations
+     if (proc->sharelabel) {
+          free(proc->sharelabel);
+     }
+     free(proc);
+
+     return 1;
+}
+

--- a/src/procs/proc_hmac.c
+++ b/src/procs/proc_hmac.c
@@ -1,0 +1,184 @@
+/*
+
+proc_hmac.c - code for cryptographically hashing items
+
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+
+*/
+#define PROC_NAME "hmac"
+
+#include <openssl/evp.h>
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "procloader_buffer.h"
+
+int is_procbuffer = 1;
+int procbuffer_pass_not_found = 1;
+
+char proc_version[] = "1.0";
+char proc_requires[]     = "";
+const char *proc_tags[] = { "annotate", NULL };
+char proc_name[] = PROC_NAME;
+char proc_purpose[] = "compute HMAC hash of strings or buffers";
+const char *proc_synopsis[] = 
+     { "hmac <LABEL> [-B] [-L <value>]", NULL };
+char proc_description[] = "Compute HMAC hash of specified strings or buffers"; 
+char *proc_alias[] = { "md5", "sha",  NULL };
+
+proc_example_t proc_examples[]    = {
+     {NULL,""}
+};
+proc_option_t proc_opts[] = {
+     /*  'option character', "long option string", "option argument",
+      "option description", <allow multiple>, <required>*/
+     {'A',"","algorithm",
+     "HMAC algorithm (md5, sha1, sha256)",0,0},
+     {'B',"","",
+     "return result as binary HMAC",0,0},
+     {'L',"","LABEL",
+     "label of HMAC",0,0},
+     //the following must be left as-is to signify the end of the array
+     {' ',"","",
+     "",0,0}
+};
+
+char *proc_tuple_member_labels[] = {"HMAC", NULL};
+char proc_nonswitch_opts[]    = "LABEL of tuple string member to hash";
+// proc_input_types and proc_output_types automatically set for procbuffer kids
+proc_port_t proc_input_ports[]     = {{NULL, NULL}};
+char *proc_tuple_container_labels[]     = {NULL};
+char *proc_tuple_conditional_container_labels[]   = {NULL};
+
+//function prototypes for local functions
+typedef struct _proc_instance_t {
+     wslabel_t * label_hmac;
+     int binary_only;
+     uint8_t digestbuf[EVP_MAX_MD_SIZE];
+     const EVP_MD *md;
+     EVP_MD_CTX *mdctx;
+} proc_instance_t;
+
+int procbuffer_instance_size = sizeof(proc_instance_t);
+
+proc_labeloffset_t proc_labeloffset[] =
+{
+     {"HMAC",offsetof(proc_instance_t, label_hmac)},
+     {"",0}
+};
+
+
+char procbuffer_option_str[]    = "a:A:L:B";
+
+int procbuffer_option(void * vproc, void * type_table, int c, const char * str) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+
+     switch(c) {
+     case 'a':
+     case 'A':
+          proc->md = EVP_get_digestbyname(str);
+          if (!proc->md) {
+               tool_print("unknown digest %s", str);
+               return 0;
+          }
+          break;
+     case 'B':
+          proc->binary_only = 1;
+          break;
+     case 'L':
+          proc->label_hmac = wsregister_label(type_table, str);
+          break;
+     }
+     return 1;
+}
+
+int procbuffer_init(void * vproc, void * type_table) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+
+     if (!proc->md) {
+          proc->md = EVP_get_digestbyname("md5");
+          tool_print("setting HMAC to MD5");
+          if (!proc->md) {
+               tool_print("unable to set default HMAC to MD5");
+               return 0;
+          }
+     }
+     proc->mdctx = EVP_MD_CTX_new();
+     if (!proc->mdctx) {
+          tool_print("unable to set HMAC context");
+          return 0;
+     }
+
+     return 1;
+
+}
+
+int procbuffer_decode(void * vproc, wsdata_t * tdata,
+                      wsdata_t * member, uint8_t * buf, int buflen) {
+     proc_instance_t * proc = (proc_instance_t*)vproc;
+
+     unsigned int dlen;
+     EVP_DigestInit_ex(proc->mdctx, proc->md, NULL);
+     EVP_DigestUpdate(proc->mdctx, buf, buflen);
+     EVP_DigestFinal_ex(proc->mdctx, proc->digestbuf, &dlen);
+     if (dlen == 0) {
+          return 1;
+     }
+
+     if (proc->binary_only) {
+          tuple_dupe_binary(tdata, proc->label_hmac, (char *)proc->digestbuf, dlen);
+          return 1;
+     }
+
+     //print hex
+     wsdt_string_t * str = tuple_create_string(tdata,
+                                               proc->label_hmac,
+                                               dlen * 2);
+
+     uint8_t * db = proc->digestbuf;
+
+     int i;
+     for (i = 0; i < dlen; i++) {
+          uint8_t upper = (db[i]>>4);
+          uint8_t lower = db[i] & 0xF;
+
+          str->buf[i*2] = (upper <= 9) ? ('0' + upper) : (upper - 10) + 'a';
+          str->buf[i*2+1] = (lower <= 9) ? ('0' + lower) : (lower - 10) + 'a';
+     }
+     
+     return 1;
+}
+
+//return 1 if successful
+//return 0 if no..
+int procbuffer_destroy(void * vinstance) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+
+     if (proc->mdctx) {
+          EVP_MD_CTX_free(proc->mdctx);
+     }
+
+     return 1;
+}
+

--- a/src/procs/proc_keyarrival.c
+++ b/src/procs/proc_keyarrival.c
@@ -1,0 +1,301 @@
+/*
+proc_keyarrival.c
+
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+*/
+
+// annotates the sequence of arrival for elements of a key starting with 1
+
+#define PROC_NAME "keyarrival"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "waterslide.h"
+#include "waterslidedata.h"
+#include "datatypes/wsdt_tuple.h"
+#include "stringhash5.h"
+#include "procloader.h"
+#include "sysutil.h"
+#include "wstypes.h"
+
+char proc_name[]               =  PROC_NAME;
+char proc_version[]            =  "1.5";
+// Use to fix proc_tags: 
+//char *proc_menus[]             =  { "Filters", NULL };
+char *proc_tags[]              =  {"Filtering", "Stream manipulation", NULL};
+char *proc_alias[]             =  { "arrival", "keyseq", "keysequence", NULL };
+char proc_purpose[]            =  "annotates the arrival sequence of each key";
+char proc_description[] = "annotates the arrival sequence of each key, starting index 0 and counting upwards.  with emit the first N tuples for each value in a specified LABEL (key). It is also possible to control the size of the storage table with the '-M' option (default value is 350000 bytes).";
+proc_option_t proc_opts[]      =  {
+     /*  'option character', "long option string", "option argument",
+	 "option description", <allow multiple>, <required>*/
+     {'L',"","LABEL",
+     "Label of sequence counter (ARRIVAL) by default",0,0},
+     {'F',"","filename",
+     "load existing database (key table) from file",0,0},
+     {'O',"","filename",
+     "write database (key table) to file",0,0},
+     {'M',"","records",
+     "maximum table size",0,0},
+     //the following must be left as-is to signify the end of the array
+     {' ',"","",
+     "",0,0}
+};
+char proc_nonswitch_opts[]     =  "LABEL of key to track";
+char *proc_input_types[]       =  {"tuple", "any", NULL};
+// (Potential) Output types: tuple
+char *proc_output_types[]      =  {"any", NULL};
+char proc_requires[]           =  "None";
+// Ports: 
+proc_port_t proc_input_ports[] =  {
+     {NULL, NULL}
+};
+char *proc_tuple_container_labels[] =  {NULL};
+char *proc_tuple_conditional_container_labels[] =  {NULL};
+char *proc_tuple_member_labels[] =  {NULL};
+char *proc_synopsis[]          =  {"keyarrival <LABEL of key> [-L <LABEL of sequence>]", NULL};
+proc_example_t proc_examples[] =  {
+	{NULL, NULL}
+};
+
+//function prototypes for local functions
+static int proc_tuple(void *, wsdata_t*, ws_doutput_t*, int);
+static int proc_flush(void *, wsdata_t*, ws_doutput_t*, int);
+
+typedef struct _key_data_t {
+     uint64_t sequence;
+} key_data_t;
+
+typedef struct _proc_instance_t {
+     uint64_t meta_process_cnt;
+     uint64_t outcnt;
+
+     uint64_t lastsequence;
+
+     ws_outtype_t * outtype_tuple;
+     stringhash5_t * key_table;
+
+     uint32_t tablemax;
+     wslabel_nested_set_t nest;
+
+     wslabel_t * label_arrival;
+     char * outfile;
+     char * open_table;
+
+} proc_instance_t;
+
+static int proc_cmd_options(int argc, char ** argv, 
+                            proc_instance_t * proc, void * type_table) {
+     int op;
+
+     while ((op = getopt(argc, argv, "O:F:L:M:")) != EOF) {
+          switch (op) {
+          case 'O':
+               proc->outfile = strdup(optarg);
+               break;
+          case 'F':
+               proc->open_table = strdup(optarg);
+               break;
+          case 'L':
+               proc->label_arrival = wsregister_label(type_table, optarg);
+               break;
+          case 'M':
+               proc->tablemax = atoi(optarg);
+               break;
+          default:
+               return 0;
+          }
+     }
+     while (optind < argc) {
+          wslabel_nested_search_build(type_table, &proc->nest, argv[optind]);
+          tool_print("using key %s", argv[optind]);
+          optind++;
+     } 
+     return 1;
+}
+
+static int read_stored_table(proc_instance_t * proc) {
+     uint64_t maxseq = 0;
+     if (!proc->open_table) {
+          return 0;
+     }
+     FILE * fp = sysutil_config_fopen(proc->open_table, "r");
+     if (!fp) {
+          tool_print("unable to open file %s", proc->open_table);
+          return 0;
+     }
+     tool_print("opening file %s", proc->open_table);
+     proc->key_table = stringhash5_read(fp);
+     if (proc->key_table) {
+          if (!fread(&maxseq, sizeof(uint64_t), 1, fp)) {
+               tool_print("error opening file %s", proc->open_table);
+               return 0;
+          }
+     }
+
+     sysutil_config_fclose(fp);
+
+     tool_print("setting last sequence number %"PRIu64, maxseq);
+     proc->lastsequence = maxseq;
+
+     return 1;
+}
+
+// the following is a function to take in command arguments and initalize
+// this processor's instance..
+//  also register as a source here..
+// return 1 if ok
+// return 0 if fail
+int proc_init(wskid_t * kid, int argc, char ** argv, void ** vinstance, ws_sourcev_t * sv,
+              void * type_table) {
+     
+     //allocate proc instance of this processor
+     proc_instance_t * proc =
+          (proc_instance_t*)calloc(1,sizeof(proc_instance_t));
+     *vinstance = proc;
+
+     ws_default_statestore(&proc->tablemax);
+
+     proc->label_arrival = wsregister_label(type_table, "ARRIVAL");
+
+     //read in command options
+     if (!proc_cmd_options(argc, argv, proc, type_table)) {
+          return 0;
+     }
+
+     if (proc->nest.cnt == 0) {
+          tool_print("must specify key to process");
+          return 0;
+     }
+
+     if (!read_stored_table(proc)) {
+          proc->key_table = stringhash5_create(0, proc->tablemax, 
+                                               sizeof(key_data_t));
+     }
+     if (!proc->key_table) {
+          return 0;
+     }
+
+     //use the stringhash5-adjusted value of max_records to reset tablemax
+     proc->tablemax = proc->key_table->max_records;
+
+     return 1; 
+}
+
+// this function needs to decide on processing function based on datatype
+// given.. also set output types as needed (unless a sink)
+//return 1 if ok
+// return 0 if problem
+proc_process_t proc_input_set(void * vinstance, wsdatatype_t * meta_type,
+                              wslabel_t * port,
+                              ws_outlist_t* olist, int type_index,
+                              void * type_table) {
+     proc_instance_t * proc = (proc_instance_t *)vinstance;
+
+     if (!proc->outtype_tuple) {
+          proc->outtype_tuple = ws_add_outtype(olist, dtype_tuple, NULL);
+     }
+
+     if (wsdatatype_match(type_table, meta_type, "FLUSH_TYPE")) {
+          return proc_flush;
+     }
+     if (meta_type == dtype_tuple) {
+          return proc_tuple;
+     }
+     // we are happy.. now set the processor function
+     return NULL; // a function pointer
+}
+
+static int nest_search_callback_match(void * vproc, void * vevent,
+                                      wsdata_t * tdata, wsdata_t * member) {
+
+     proc_instance_t * proc = vproc;
+     key_data_t * kdata;
+     kdata = (key_data_t *)stringhash5_find_attach_wsdata(proc->key_table, member);
+     if (!kdata) {
+          return 0;
+     }
+     if (kdata->sequence == 0) {
+          kdata->sequence = proc->lastsequence + 1;
+          proc->lastsequence++;
+     }
+     tuple_member_create_uint64(tdata, kdata->sequence, proc->label_arrival);
+     return 1;
+}
+
+//// proc processing function assigned to a specific data type in proc_io_init
+//return 1 if output is available
+// return 0 if not output
+static int proc_tuple(void * vinstance, wsdata_t* input_data,
+                      ws_doutput_t * dout, int type_index) {
+
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     proc->meta_process_cnt++;
+
+     tuple_nested_search(input_data, &proc->nest, nest_search_callback_match,
+                         proc, NULL);
+     // this is new data.. pass as output
+     ws_set_outdata(input_data, proc->outtype_tuple, dout);
+     proc->outcnt++;
+     return 1;
+}
+
+
+static void serialize_table(proc_instance_t * proc) {
+     if (proc->outfile) {
+          tool_print("Writing key table to %s", proc->outfile);
+          FILE * fp = fopen(proc->outfile, "w");
+          if (fp) {
+               if (stringhash5_dump(proc->key_table, fp)) {
+                    //add last sequence to end of record 
+                    fwrite(&proc->lastsequence, sizeof(uint64_t), 1, fp);
+               }
+               fclose(fp);
+          }
+     }
+}
+
+static int proc_flush(void * vinstance, wsdata_t* input_data,
+                      ws_doutput_t * dout, int type_index) {
+
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+
+     serialize_table(proc);
+
+     return 1;
+}
+
+//return 1 if successful
+//return 0 if no..
+int proc_destroy(void * vinstance) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     tool_print("meta_proc cnt %" PRIu64, proc->meta_process_cnt);
+     tool_print("output cnt %" PRIu64, proc->outcnt);
+
+     //destroy table
+     stringhash5_destroy(proc->key_table);
+
+     free(proc);
+
+     return 1;
+}
+

--- a/src/procs/proc_keysort.c
+++ b/src/procs/proc_keysort.c
@@ -1,0 +1,451 @@
+/*
+proc_keysort.c
+
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+ */
+
+#define PROC_NAME "keysort"
+//#define DEBUG 1
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <netinet/tcp.h>
+#include "waterslide.h"
+#include "waterslidedata.h"
+#include "datatypes/wsdt_tuple.h"
+#include "stringhash5.h"
+#include "evahash64_data.h"
+#include "procloader.h"
+
+char proc_name[]               =  PROC_NAME;
+char proc_version[]            =  "1.5";
+char *proc_tags[]              =  {"Sessionization", "State tracking", NULL};
+char *proc_alias[]             =  { "sortkey", "groupsort", "sortgroup", NULL };
+char proc_purpose[]            =  "sorts events about a key from lowest to highest value";
+char proc_description[] = "streaming window sort of events per key, pressure expiration";
+
+proc_option_t proc_opts[]      =  {
+     /*  'option character', "long option string", "option argument",
+	 "option description", <allow multiple>, <required>*/
+     {'V',"","LABEL",
+     "value to sort on",0,0},
+     {'n',"","count",
+     "maximum number of events to store at key",0,0},
+     {'M',"","records",
+     "maximum table size",0,0},
+     //the following must be left as-is to signify the end of the array
+     {' ',"","",
+     "",0,0}
+};
+
+char proc_nonswitch_opts[]     =  "LABEL of key to index on";
+char *proc_input_types[]       =  {"any","tuple", NULL};
+// (Potential) Output types: tuple
+char *proc_output_types[]      =  {"tuple", NULL};
+char proc_requires[]           =  "";
+// Ports: 
+proc_port_t proc_input_ports[] =  {
+     {"none","Store value at key"},
+     {"EXPIRE","trigger expiration of all buffered state"},
+     {NULL, NULL}
+};
+char *proc_tuple_container_labels[] =  {NULL};
+char *proc_tuple_conditional_container_labels[] =  {NULL};
+char *proc_tuple_member_labels[] =  {NULL};
+
+typedef struct _el_data_t {
+     double value;
+     wsdata_t * data;
+} el_data_t;
+
+typedef struct _key_data_t {
+     uint32_t next;
+     uint32_t generation; //for expiration
+     el_data_t el[0];
+} key_data_t;
+
+//function prototypes for local functions
+static int proc_tuple(void *, wsdata_t*, ws_doutput_t*, int);
+static int proc_expire(void *, wsdata_t*, ws_doutput_t*, int);
+static int proc_flush(void *, wsdata_t*, ws_doutput_t*, int);
+
+typedef struct _proc_instance_t {
+     uint64_t meta_process_cnt;
+     uint64_t outcnt;
+
+     stringhash5_t * session_table;
+     uint32_t buflen;
+     wslabel_nested_set_t nest_key;
+     wslabel_nested_set_t nest_value;
+
+     ws_outtype_t * outtype_tuple;
+     ws_doutput_t * dout;
+
+     uint32_t maxcnt;  //max number of events per key
+     size_t key_struct_size;
+
+     key_data_t * global_key; //when not key is specified, use a global key table
+     uint32_t generation;
+
+} proc_instance_t;
+
+
+static int proc_cmd_options(int argc, char ** argv, 
+                            proc_instance_t * proc, void * type_table) {
+     dprint("proc_cmd_options");
+     int op;
+
+     while ((op = getopt(argc, argv, "v:V:N:n:M:")) != EOF) {
+          switch (op) {
+          case 'V':
+          case 'v':
+               wslabel_nested_search_build(type_table, &proc->nest_value, optarg);
+               break;
+          case 'N':
+          case 'n':
+               proc->maxcnt = atoi(optarg);
+               tool_print("storing %d objects at key", proc->maxcnt);
+               if(proc->maxcnt <= 0) {
+                    error_print("invalid count of objects ... specified %d",
+                                proc->maxcnt);
+                    return 0;
+               }
+               break;
+          case 'M':
+               proc->buflen = atoi(optarg);
+               break;
+          default:
+               return 0;
+          }
+     }
+     while (optind < argc) {
+          wslabel_nested_search_build(type_table, &proc->nest_key, argv[optind]);
+          tool_print("using key %s", argv[optind]);
+          optind++;
+     }
+     
+     return 1;
+}
+
+static void emit_state(void * vdata, void * vproc) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+     key_data_t * kdata = (key_data_t *)vdata;
+
+     dprint("emit_state");
+     //flush all stored content
+     uint32_t i;
+     for (i = 0; i < proc->maxcnt; i++) {
+          uint32_t k = (i + kdata->next) % proc->maxcnt;
+          if (kdata->el[k].data) {
+               ws_set_outdata(kdata->el[k].data, proc->outtype_tuple, proc->dout);
+               wsdata_delete(kdata->el[k].data);
+          }
+     }
+
+     memset(kdata, 0, proc->key_struct_size);
+}
+
+#define DEFAULT_TABLE_SIZE (50000)
+
+// the following is a function to take in command arguments and initalize
+// this processor's instance..
+//  also register as a source here..
+// return 1 if ok
+// return 0 if fail
+int proc_init(wskid_t * kid, int argc, char ** argv, void ** vinstance, ws_sourcev_t * sv,
+              void * type_table) {
+
+     dprint("proc_init");     
+     //allocate proc instance of this processor
+     proc_instance_t * proc =
+          (proc_instance_t*)calloc(1,sizeof(proc_instance_t));
+     *vinstance = proc;
+
+     proc->buflen = DEFAULT_TABLE_SIZE;
+
+     proc->maxcnt = 20;
+     proc->generation = 1;
+
+     //read in command options
+     if (!proc_cmd_options(argc, argv, proc, type_table)) {
+          return 0;
+     }
+
+     if (!proc->nest_value.cnt) {
+          tool_print("need to specify a value to sort");
+          return 0;
+     }
+     tool_print("storing %u values per key", proc->maxcnt);
+     proc->key_struct_size = sizeof(key_data_t) + 
+          (sizeof(el_data_t) * proc->maxcnt);
+
+     if (proc->nest_key.cnt) {
+          //other init - init the stringhash table
+          proc->session_table = stringhash5_create(0, proc->buflen,
+                                                   proc->key_struct_size);
+          if (!proc->session_table) {
+               return 0;
+          }
+          stringhash5_set_callback(proc->session_table, emit_state, proc);
+          proc->buflen = proc->session_table->max_records;
+     }
+     else {
+          tool_print("no key defined, using global key");
+          proc->global_key = calloc(1, proc->key_struct_size);
+     }
+
+     //use the stringhash5-adjusted value of max_records to reset buflen
+
+     return 1; 
+}
+
+// this function needs to decide on processing function based on datatype
+// given.. also set output types as needed (unless a sink)
+//return 1 if ok
+// return 0 if problem
+proc_process_t proc_input_set(void * vinstance, wsdatatype_t * meta_type,
+                              wslabel_t * port,
+                              ws_outlist_t* olist, int type_index,
+                              void * type_table) {
+     proc_instance_t * proc = (proc_instance_t *)vinstance;
+     if (wslabel_match(type_table, port, "EXPIRE")) {
+          if (wsdatatype_match(type_table, meta_type, "TUPLE_TYPE")) {
+               tool_print("doing expire processing");
+               return proc_expire;
+          }
+          return NULL;
+     }
+
+     if (wsdatatype_match(type_table, meta_type, "FLUSH_TYPE")) {
+          proc->outtype_tuple = ws_add_outtype(olist, wsdatatype_get(type_table,
+                                                                     "TUPLE_TYPE"), NULL);
+          return proc_flush;
+     }
+     if (wsdatatype_match(type_table, meta_type, "TUPLE_TYPE")) {
+          proc->outtype_tuple = ws_add_outtype(olist, meta_type, NULL);
+          return proc_tuple;
+     }
+
+     return NULL; // a function pointer
+}
+
+
+//only select first key found as key to use
+static int nest_search_key(void * vproc, void * vkey,
+                           wsdata_t * tdata, wsdata_t * member) {
+     dprint("nest_search_key");
+     //proc_instance_t * proc = (proc_instance_t*)vproc;
+     wsdata_t ** pkey = (wsdata_t **)vkey;
+     wsdata_t * key = *pkey;
+     if (!key) {
+          *pkey = member;
+          return 1;
+     }
+     return 0;
+}
+
+static inline void replace_kv(proc_instance_t * proc, key_data_t * kdata,
+                      double dv, wsdata_t * tdata) {
+     uint32_t pos = kdata->next;
+
+     dprint("replace_kv %u", pos);
+     if (kdata->el[pos].data) {
+          dprint("emit data");
+          ws_set_outdata(kdata->el[pos].data, proc->outtype_tuple, proc->dout);
+          wsdata_delete(kdata->el[pos].data);
+     }
+     kdata->el[pos].value = dv;
+     kdata->el[pos].data = tdata;
+     wsdata_add_reference(tdata);
+     kdata->next = (kdata->next + 1) % proc->maxcnt;
+}
+
+static void insert_kv(proc_instance_t * proc, key_data_t * kdata,
+                     wsdata_t * value, wsdata_t * tdata) {
+     dprint("insert kv");
+    
+     double dv = 0; 
+     if (!dtype_get_double(value, &dv)) {
+          dprint("could not convert to double");
+          return; 
+     }
+     dprint("current value %.0f", dv);
+
+     //check immediate prior values
+     uint32_t p = (proc->maxcnt + kdata->next - 1) % proc->maxcnt;  
+     if (!kdata->el[p].data || (kdata->el[p].value <= dv)) {
+          dprint("in order insert: %f", dv);
+          replace_kv(proc, kdata, dv, tdata);
+          return;
+     }
+     //check lowest value
+     if (kdata->el[kdata->next].value > dv) {
+          //emit tdata without insertion
+          //TODO: decide that value is too off -- reset (detect reboot)
+          dprint("insert prior");
+          ws_set_outdata(tdata, proc->outtype_tuple, proc->dout);
+          return;
+     }
+
+     //emit oldest one.. 
+     if (kdata->el[kdata->next].data) {
+          ws_set_outdata(kdata->el[kdata->next].data, proc->outtype_tuple, proc->dout);
+          wsdata_delete(kdata->el[kdata->next].data);
+     }
+
+     //ok out of order.. do more complicated stuff
+     dprint("out of order");
+     uint32_t prev = kdata->next;
+     uint32_t i;
+     for (i = 1; i < proc->maxcnt; i++) {
+          uint32_t cursor = (kdata->next + i) % proc->maxcnt;
+          if (kdata->el[cursor].value <= dv) {
+               //shift to fill space
+               kdata->el[prev].value = kdata->el[cursor].value;
+               kdata->el[prev].data = kdata->el[cursor].data; 
+          }
+          else {
+               dprint("found hole");
+               kdata->el[prev].value = dv;
+               kdata->el[prev].data = tdata;
+               wsdata_add_reference(tdata);
+               return;
+          }
+          prev = cursor;
+     }
+     dprint("unexpected exit!!!!!");
+
+}
+
+static void expire_state(void * vdata, void * vproc) {
+     key_data_t * kdata = (key_data_t *)vdata;
+     proc_instance_t * proc = (proc_instance_t*)vproc;
+     if (!kdata->generation) {
+          return;
+     }
+     if (kdata->generation != proc->generation) {
+          emit_state(vdata, vproc);
+     }
+}
+
+static int proc_expire(void * vinstance, wsdata_t* input_data,
+                       ws_doutput_t * dout, int type_index) {
+
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     proc->dout = dout;
+     tool_print("proc_expire!!!");
+     if (proc->global_key) {
+          expire_state(proc->global_key, proc);
+     }
+     else {
+          //walk entire hashtable..
+          stringhash5_scour(proc->session_table, expire_state, proc);
+     }
+     proc->generation++;
+     if (proc->generation == 0) {
+          proc->generation = 1;
+     }
+     return 1;
+}
+
+//// proc processing function assigned to a specific data type in proc_io_init
+static int proc_tuple(void * vinstance, wsdata_t* input_data,
+                        ws_doutput_t * dout, int type_index) {
+
+     dprint("proc_tuple");
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     proc->dout = dout;
+     proc->meta_process_cnt++;
+     key_data_t * kdata = NULL;
+     wsdata_t * key = NULL;
+
+
+     //check if using hashtable.. otherwise global key
+     if (proc->global_key) {
+          kdata = proc->global_key;
+     }
+     else if (proc->session_table) {
+          tuple_nested_search(input_data, &proc->nest_key,
+                              nest_search_key,
+                              proc, &key);
+          if (key) {
+               kdata = (key_data_t *) stringhash5_find_attach_wsdata(proc->session_table, key);
+          }
+     }
+
+     if (!kdata) {
+          return 0;
+     }
+     kdata->generation = proc->generation;
+
+     wsdata_t * value = NULL;
+     if (tuple_nested_search(input_data, &proc->nest_value,
+                             nest_search_key,
+                             proc, &value) ) {
+          if (value) {
+               insert_kv(proc, kdata, value, input_data);
+          }
+     }
+     
+     //always return 1 since we don't know if table will flush old data
+     return 1;
+}
+
+static int proc_flush(void * vinstance, wsdata_t* input_data,
+                        ws_doutput_t * dout, int type_index) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     proc->dout = dout;
+
+     // Note:  the following seems backwards.  But, if hitemit is set, we only
+     // want full sets of elements, so rec_erase is used to throw away all of 
+     // the partials at flush time.  But, if hitemit is not set, then we are
+     // expecting the partials, hence the use of emit_state here.
+     if (proc->global_key) {
+          emit_state(proc->global_key, proc);
+     }
+     else if (proc->session_table) {
+          stringhash5_scour_and_flush(proc->session_table, emit_state, proc);
+     }
+
+     return 1;
+}
+
+//return 1 if successful
+//return 0 if no..
+int proc_destroy(void * vinstance) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     tool_print("meta_proc cnt %" PRIu64, proc->meta_process_cnt);
+     tool_print("output cnt %" PRIu64, proc->outcnt);
+
+     //destroy table
+     if (proc->global_key) {
+          free(proc->global_key);
+     }
+     else if (proc->session_table) {
+          stringhash5_destroy(proc->session_table);
+     }
+
+     //free dynamic allocations
+     free(proc);
+
+     return 1;
+}
+

--- a/src/procs/proc_keytrans.c
+++ b/src/procs/proc_keytrans.c
@@ -1,0 +1,189 @@
+/*
+proc_keytrans.c -- time state transitions in value per key
+
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+ */
+#define PROC_NAME "keytrans"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "waterslide.h"
+#include "waterslidedata.h"
+#include "datatypes/wsdt_tuple.h"
+#include "datatypes/wsdt_uint.h"
+#include "datatypes/wsdt_double.h"
+#include "procloader_keystate.h"
+#include "evahash64_data.h"
+#include "sysutil.h"
+
+int is_prockeystate = 1;
+
+char proc_version[]     = "1.1";
+char *proc_alias[]     = { NULL };
+char proc_name[]       = PROC_NAME;
+char proc_purpose[]    = "time transitions in value per key";
+
+proc_option_t proc_opts[] = {
+     /*  'option character', "long option string", "option argument",
+	 "option description", <allow multiple>, <required>*/
+     {'V',"","data",
+     "value to detect transition",0,0},
+     {'M',"","records",
+     "maximum table size",0,0},
+     {'L',"","label",
+     "record count as label",0,0},
+     //the following must be left as-is to signify the end of the array
+     {' ',"","",
+     "",0,0}
+};
+
+char proc_nonswitch_opts[]    = "LABEL of key to count";
+char *proc_input_types[]    = {"tuple", NULL};
+char *proc_output_types[]    = {"tuple", NULL};
+char *proc_tuple_member_labels[] = {"COUNT", NULL};
+
+typedef struct _key_data_t {
+     wsdt_ts_t last;
+     uint64_t state;
+} key_data_t;
+
+int prockeystate_state_size = sizeof(key_data_t);
+
+typedef struct _proc_instance_t {
+     wslabel_t * label_ts;
+     wslabel_t * label_timediff;
+     uint32_t seed;
+     int keepfirst;
+} proc_instance_t;
+
+int prockeystate_instance_size = sizeof(proc_instance_t);
+
+proc_labeloffset_t proc_labeloffset[] =
+{
+     {"TIMEDIFF",offsetof(proc_instance_t, label_timediff)},
+     {"",0}
+};
+
+char prockeystate_option_str[]    = "fFL:";
+
+int prockeystate_option(void * vproc, void * type_table, int c, const char * str) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+
+     switch(c) {
+     case 'F':
+     case 'f':
+          proc->keepfirst = 1;
+          break;
+     case 'L':
+          proc->label_timediff = wsregister_label(type_table, str);
+          break; 
+     }
+
+     return 1;
+}
+
+int prockeystate_init(void * vproc, void * type_table, int hasvalue) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+
+     proc->label_ts = wssearch_label(type_table, "DATETIME");
+     proc->seed = rand();
+
+     return 1;
+}
+
+static wsdt_ts_t * get_datetime(proc_instance_t * proc, wsdata_t * tdata) {
+     wsdata_t ** mset;
+     int mset_len;
+     wsdt_ts_t * ts = NULL;
+     if (tuple_find_label(tdata, proc->label_ts,
+                          &mset_len, &mset)) {
+          if (mset_len && (mset[0]->dtype == dtype_ts)) {
+               //just choose first
+               ts = mset[0]->data;
+          }
+     }
+     return ts;
+}
+
+static void add_timediff(proc_instance_t * proc, wsdata_t * tdata,
+                         wsdt_ts_t * ts, key_data_t * kdata) {
+     double tnew = (double)ts->sec + (double)ts->usec/1000000;
+     double last = (double)kdata->last.sec + (double)kdata->last.usec/1000000;
+     double diff = tnew - last;
+     tuple_member_create_double(tdata, diff, proc->label_timediff);
+}
+
+int prockeystate_update(void * vproc, void * vstate, wsdata_t * tdata,
+                        wsdata_t *key) {
+     proc_instance_t * proc = (proc_instance_t*)vproc;
+     key_data_t * kdata = (key_data_t *) vstate;
+     wsdt_ts_t * ts = get_datetime(proc, tdata);
+     if (!ts) {
+          return 0;
+     }
+
+     if (!kdata->last.sec) {
+          kdata->state = 1;
+     }
+     else {
+          add_timediff(proc, tdata, ts, kdata);
+     }
+     kdata->last.sec = ts->sec;
+     kdata->last.usec = ts->usec;
+     return 1;
+}
+int prockeystate_update_value(void * vproc, void * vstate, wsdata_t * tdata,
+                              wsdata_t *key, wsdata_t *value) {
+
+     proc_instance_t * proc = (proc_instance_t*)vproc;
+     key_data_t * kdata = (key_data_t *) vstate;
+
+     uint64_t v64 = evahash64_data(value, proc->seed); //hash value
+
+
+     wsdt_ts_t * ts = get_datetime(proc, tdata);
+     if (!ts) {
+          return 0;
+     }
+
+     if (!kdata->state && !kdata->last.sec) {
+          kdata->state = v64;
+          kdata->last.sec = ts->sec;
+          kdata->last.usec = ts->usec;
+     }
+     else if (kdata->state != v64) {
+          add_timediff(proc, tdata, ts, kdata);
+          kdata->state = v64;
+          kdata->last.sec = ts->sec;
+          kdata->last.usec = ts->usec;
+     }
+     else if (!proc->keepfirst) {
+          kdata->last.sec = ts->sec;
+          kdata->last.usec = ts->usec;
+     }
+     //memcpy(&kdata->last, ts, sizeof(wsdt_ts_t));
+     
+     return 1;
+}
+
+

--- a/src/procs/proc_log_keyvalue_parse.c
+++ b/src/procs/proc_log_keyvalue_parse.c
@@ -1,0 +1,529 @@
+/*
+
+proc_log_keyvalue_parse.c -- parse logs with key=value pairs
+
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+*/
+
+#define PROC_NAME "log_keyvalue_parse"
+//#define DEBUG 1
+#include <stdlib.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <ctype.h>
+#include "waterslide.h"
+#include "datatypes/wsdt_tuple.h"
+#include "datatypes/wsdt_string.h"
+#include "datatypes/wsdt_binary.h"
+#include "datatypes/wsdt_fixedstring.h"
+#include "waterslidedata.h"
+#include "procloader.h"
+#include "wstypes.h"
+#include "mimo.h"
+
+char proc_version[]     = "1.5";
+char *proc_tags[] = {"Decode", NULL};
+char *proc_menus[]     = { "Filters", NULL };
+char *proc_alias[]     = { "kvparse", "kvlog", "kvp", "syslog", NULL };
+char proc_name[]       = PROC_NAME;
+char proc_purpose[]    = "decode logs that have key=value substrings";
+char *proc_synopsis[] = { "substring LABEL_TO_SUBSTRING", NULL};
+char proc_description[] = "decode a string from a log into key, values.  Useful for syslog parsing.";
+proc_example_t proc_examples[] = {
+     {NULL,""}
+};
+char proc_requires[] = "";
+// proc_input_types and proc_output_types automatically set for procbuffer kids
+proc_port_t proc_input_ports[] = {{NULL,NULL}};
+char *proc_tuple_container_labels[] = {NULL};
+char *proc_tuple_conditional_container_labels[] = {NULL};
+char *proc_tuple_member_labels[] = {NULL};
+char proc_nonswitch_opts[] = "";
+
+proc_option_t proc_opts[] = {
+     /*  'option character', "long option string", "option argument",
+	 "option description", <allow multiple>, <required>*/
+     {'R',"","character",
+     "delimiter for records",0,0},
+     {'k',"","character",
+     "delimiter between key and value",0,0},
+     {'N',"","LABEL",
+     "label of subtuple",0,0},
+     {'X',"","",
+     "detect and decode hex strings",0,0},
+     {'E',"","LABEL",
+     "label to apply when no key is found",0,0},
+     {'A',"","LABEL",
+     "decode all values into a common string",0,0},
+     {'I',"","string",
+     "ignore elements with a specified key name (can call multiple times)",0,0},
+     {'L',"","LABEL prefix",
+     "prefix to every new key",0,0},
+     //the following must be left as-is to signify the end of the array
+     {' ',"","",
+     "",0,0}
+};
+
+int is_procbuffer = 1;
+
+int procbuffer_pass_not_found = 1;
+
+#define MAX_LABEL_LEN (64)
+
+typedef struct _ignore_item_t {
+     char * buf;
+     int len;
+} ignore_item_t;
+
+typedef struct _proc_instance_t {
+     size_t label_prefix_len;
+     char label_buffer[MAX_LABEL_LEN + 1];
+     wslabel_t * label_subtuple;
+     wslabel_t * label_nokey;
+     uint8_t record_delimiter;
+     uint8_t kv_delimiter;
+     uint8_t quote;
+     int detecthex;
+     void * type_table;
+     ignore_item_t * ignore_list;
+     int ignore_cnt;
+     
+     wslabel_t * label_allvalues;
+     int all_len;
+     wsdt_string_t * str_allvalues;
+} proc_instance_t;
+
+int procbuffer_instance_size = sizeof(proc_instance_t);
+
+proc_labeloffset_t proc_labeloffset[] =
+{
+     {"KVPARSE", offsetof(proc_instance_t, label_subtuple)},
+     {"NOKEY", offsetof(proc_instance_t, label_nokey)},
+     {"",0}
+};
+
+char procbuffer_option_str[]    = "a:A:i:I:XR:K:k:N:L:";
+
+int procbuffer_option(void * vproc, void * type_table,
+                      int c, const char * str) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+
+     switch(c) {
+          case 'X':
+               proc->detecthex = 1;
+               tool_print("no hex parsing");
+               break;
+          case 'R':
+               if (strlen(str) > 0) {
+                    proc->record_delimiter = (uint8_t)str[0];
+                    tool_print("record delimiter set to '%c'", str[0]);
+               }
+               break;
+          case 'a':
+          case 'A':
+               proc->label_allvalues = wsregister_label(type_table, str);
+               break;
+          case 'i':
+          case 'I':
+               {
+                    proc->ignore_cnt++;
+                    proc->ignore_list = (ignore_item_t*)realloc(proc->ignore_list,
+                                                        proc->ignore_cnt *
+                                                        sizeof(ignore_item_t));
+                    if (!proc->ignore_list) {
+                         tool_print("error allocating ignore list");
+                         return 0;
+                    }
+                    proc->ignore_list[proc->ignore_cnt-1].buf = strdup(str);
+                    proc->ignore_list[proc->ignore_cnt-1].len = strlen(str);
+                    break;
+               }
+          case 'K':
+          case 'k':
+               if (strlen(str) > 0) {
+                    proc->kv_delimiter = (uint8_t)str[0];
+                    tool_print("key-value delimiter set to '%c'", str[0]);
+               }
+               break;
+          case 'N':
+               proc->label_subtuple = wsregister_label(type_table, str);
+               tool_print("subtuple label set to %s", str);
+               break;
+          case 'E':
+               proc->label_nokey = wsregister_label(type_table, str);
+               tool_print("nokey set to %s", str);
+               break;
+          case 'L':
+               proc->label_prefix_len = strlen(str);
+               if (proc->label_prefix_len < MAX_LABEL_LEN) {
+                    memcpy(proc->label_buffer, str,
+                           proc->label_prefix_len);
+               }
+               else {
+                    tool_print("label length too long");
+                    return 0;
+               }
+               tool_print("setting label prefix to %s", str);
+               break;
+          default:
+               return 0;
+     }
+     return 1;
+}
+
+int procbuffer_init(void *vproc, void *type_table) {
+     proc_instance_t * proc = (proc_instance_t*)vproc;
+     proc->type_table = type_table;
+
+     if (!proc->record_delimiter) {
+          proc->record_delimiter = ' ';
+     }
+     if (!proc->kv_delimiter) {
+          proc->kv_delimiter = '=';
+     }
+     return 1;
+}
+
+static int32_t get_current_index_size(void * type_table) {
+     mimo_datalists_t * mdl = (mimo_datalists_t *) type_table;
+     return mdl->index_len;
+}
+
+static wslabel_t * get_key_label(proc_instance_t * proc, uint8_t * startkey,
+                                 size_t len) {
+     if (len <= 0) {
+          return NULL;
+     }
+     //check if key should be ignored
+     int i;
+     for (i = 0; i < proc->ignore_cnt; i++) {
+          if ((len == proc->ignore_list[i].len) &&
+              (memcmp(startkey, proc->ignore_list[i].buf, len) == 0)) {
+               return NULL;
+          }
+     }
+
+     if (proc->label_allvalues) {
+          return proc->label_nokey;
+     }
+     if ((len + proc->label_prefix_len) > MAX_LABEL_LEN) {
+          len = MAX_LABEL_LEN - proc->label_prefix_len;
+     }
+     //copy string onto null terminated buffer
+     memcpy(proc->label_buffer + proc->label_prefix_len, startkey, len); 
+     proc->label_buffer[proc->label_prefix_len + len] = 0;
+
+     return wsregister_label(proc->type_table, proc->label_buffer);
+}
+
+static inline uint8_t get_xdigit(uint8_t c) {
+     if (isdigit(c)) {
+          return (c - 0x30);
+     }
+     else if (isupper(c)) {
+          return (c - 0x37);
+     }
+     else {
+          return (c - 0x57);
+     }
+}
+
+static char * get_allvalues_buf(proc_instance_t * proc, wsdata_t * tuple, int len) {
+     dprint("get_allvalues_buf %d", len);
+     if (!proc->label_allvalues) {
+          dprint("nolabel");
+          return NULL;
+     }
+     if (!proc->str_allvalues) {
+          proc->str_allvalues = 
+               tuple_create_string(tuple, proc->label_allvalues, proc->all_len);     
+          if (!proc->str_allvalues) {
+               dprint("str not allocated");
+               return NULL;
+          }
+          proc->str_allvalues->len = 0;
+     }
+     if ((proc->str_allvalues->len + 1 + len) > proc->all_len) {
+          //string will not fit!!
+          dprint("str not fitting %d %d %d", proc->all_len, len,
+                 proc->str_allvalues->len);
+          return NULL;
+     }
+     if (proc->str_allvalues->len) {
+          proc->str_allvalues->buf[proc->str_allvalues->len] = ' ';
+          proc->str_allvalues->len++;
+     }
+
+     char * offset = proc->str_allvalues->buf + proc->str_allvalues->len;
+     proc->str_allvalues->len += len;
+     return offset;
+}
+
+static int add_hex_str(proc_instance_t * proc, wsdata_t * tuple,
+                                wslabel_t * label_key,
+                                uint8_t *buf, int buflen ) {
+
+     dprint("add hex str");
+     //tool_print("add_hex_str %d", buflen);
+     //check if entire buffer is hexascii
+     if (!buflen || ((buflen%2) != 0)) {
+          return 0;
+     }
+     int i;
+     for (i = 0; i < buflen; i++) {
+          if (!isxdigit(buf[i])) {
+               return 0;
+          }
+     }
+     //get buffer for output
+     uint8_t * outbuf = NULL;
+     if (proc->label_allvalues ) {
+          int tlen = (buflen/2);
+          outbuf = (uint8_t*)get_allvalues_buf(proc, tuple, tlen+2);
+          outbuf[0] = '\'';
+          outbuf[tlen+1] = '\'';
+          outbuf++;
+     }
+     else {
+          wsdt_string_t * str = tuple_create_string(tuple, label_key,
+                                                    (buflen/2));
+          if (str) {
+               outbuf = (uint8_t*)str->buf;
+          }
+     }
+
+     if (!outbuf) {
+          return 0;
+     }
+     int x = 0;
+     for (i = 0; i < buflen; i = i+2) {
+          outbuf[x] = (get_xdigit(buf[i]) << 4) + (get_xdigit(buf[i+1]));
+          x++;
+     }
+     //tool_print("outbuffer %d", str->len);
+
+     return 1;
+}
+
+static void add_key_value_dep(proc_instance_t * proc, wsdata_t * tuple,
+                              wsdata_t * member, wslabel_t * label_key,
+                              char * value, int len) {
+
+     dprint("add key value dep");
+     if (proc->label_allvalues) {
+          char * dest = get_allvalues_buf(proc, tuple, len);
+          if (dest) {
+               memcpy(dest, value, len);
+          }
+     }
+     else {
+          tuple_member_create_dep_string(tuple, member,
+                                         label_key, value, len);
+     }
+}
+
+///returns length of parsed buffer
+static size_t get_next_record(proc_instance_t * proc,
+                              wsdata_t * tuple, wsdata_t * member,
+                              uint8_t * buf, int len) {
+
+     uint8_t * startbuf = buf;
+
+     //see if there is whitespace in front..
+     while (len && (buf[0] == proc->record_delimiter)) {
+          buf += 1;
+          len -= 1;
+     }
+     if (!len) {
+          return (buf - startbuf);
+     } 
+
+     //start looking for kv_delimiter
+     uint8_t * startkey = buf;
+     uint8_t * keyend = NULL;
+     uint8_t * vstart = NULL;
+     uint8_t * vend = NULL;
+
+     int uses_quotes = 0;
+
+     while(len && (buf[0] != proc->record_delimiter)) {
+          //look for quotes
+          if ((buf == vstart) && (buf[0] == '"')) {
+               uses_quotes = 1;
+               //look for end of quote..
+               buf += 1;
+               len -= 1;
+               vstart = buf;
+               vend = NULL;
+               while (len) {
+                   if (buf[0] == '"') {
+                        vend = buf;
+                        buf +=1;
+                        len -=1;
+                        break;
+                   }
+                   buf += 1;
+                   len -= 1;
+               }
+               if (!vend) {
+                    return (buf - startbuf);
+               }
+               break;
+               
+          }
+          if (buf[0] == proc->kv_delimiter) {
+               if (!keyend) {
+                    keyend = buf;
+               }
+               if (len > 1) {
+                    vstart = buf + 1;
+               }
+          }
+          buf += 1;
+          len -= 1;
+     }
+     //key no value... ignore??
+     if (vstart) {
+          wslabel_t * label_key = get_key_label(proc, startkey,
+                                                keyend - startkey);
+          if (label_key) { //check if we are not going to ignore this key
+               if (!vend) {
+                    vend = buf;
+               }
+               if (vend > vstart) {
+                    if (!proc->detecthex || uses_quotes || 
+                        !add_hex_str(proc, tuple,
+                                     label_key,
+                                     vstart, vend - vstart)) {
+
+                         add_key_value_dep(proc, tuple, member, label_key,
+                                           (char *)vstart, vend - vstart);
+                    }
+               }
+               else {
+                    //value is null..
+                    if (!proc->label_allvalues) {
+                         char * nullv = "NULL";
+                         tuple_dupe_string(tuple, label_key, nullv, 4);
+                    }
+               }
+          }
+          else {
+               //we are going to ignore this key/value
+          }
+     }
+     else if (buf > startkey) {
+          if (!keyend) {
+               keyend = buf;
+          }
+          if (keyend > startkey) {
+               //nokey value
+
+               add_key_value_dep(proc, tuple, member, proc->label_nokey,
+                                 (char *)startkey, keyend - startkey);
+          }
+     }
+
+     return (buf - startbuf);
+}
+
+static int extract_allvalues(proc_instance_t * proc, wsdata_t * tuple,
+                             wsdata_t * member,
+                             uint8_t * buf, int len) {
+
+     proc->all_len = len; //set total length
+     proc->str_allvalues = NULL;
+
+     while(len > 0) {
+          int rlen = (int)get_next_record(proc, tuple, member, buf, len);
+
+          if (rlen <= 0) {
+               break;
+          }
+          buf += rlen;
+          len -= rlen;
+     }
+     return 1;
+}
+
+int procbuffer_decode(void * vproc, wsdata_t * tuple,
+                      wsdata_t * member,
+                      uint8_t * buf, int len) {
+     proc_instance_t * proc = (proc_instance_t*)vproc;
+
+     if (proc->label_allvalues) {
+          return extract_allvalues(proc, tuple, member, buf, len);
+     }
+
+     //number of labels before parsing
+     uint32_t start_index_size = get_current_index_size(proc->type_table);
+
+     wsdata_t * subtuple = wsdata_alloc(dtype_tuple);
+     if (!subtuple) {
+          return 1;
+     }
+     wsdata_add_label(subtuple, proc->label_subtuple);
+
+     while(len > 0) {
+          int rlen = (int)get_next_record(proc, subtuple, member, buf,len);
+
+          if (rlen <= 0) {
+               break;
+          }
+          buf += rlen;
+          len -= rlen;
+     }
+
+
+     uint32_t end_index_size = get_current_index_size(proc->type_table);
+     if (start_index_size != end_index_size) {
+          dprint("reapplying tuple labels");
+          wsdata_t * newsub = wsdata_alloc(dtype_tuple);
+          if (!newsub) {
+               wsdata_delete(subtuple);
+               return 1;
+          }
+          if (!tuple_deep_copy(subtuple, newsub)) {
+               wsdata_delete(subtuple);
+               wsdata_delete(newsub);
+               return 1;
+          }
+          wsdata_delete(subtuple);
+          subtuple = newsub;
+     }
+
+     add_tuple_member(tuple, subtuple);
+
+     return 1;
+}
+
+//return 1 if successful
+//return 0 if no..
+int procbuffer_destroy(void * vinstance) {
+     //proc_instance_t * proc = (proc_instance_t*)vinstance;
+
+     //free dynamic allocations
+     //free(proc); // free this in the calling function
+
+     return 1;
+}
+

--- a/src/procs/proc_onlyafter.c
+++ b/src/procs/proc_onlyafter.c
@@ -1,0 +1,166 @@
+/*
+
+proc_onlyafter.c  - filter out until matched label condition is met
+
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+*/
+#define PROC_NAME "onlyafter"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "waterslide.h"
+#include "waterslidedata.h"
+#include "datatypes/wsdt_tuple.h"
+#include "datatypes/wsdt_uint.h"
+#include "datatypes/wsdt_double.h"
+#include "procloader_keystate.h"
+#include "evahash64_data.h"
+#include "sysutil.h"
+
+int is_prockeystate = 1;
+
+char proc_version[]     = "1.1";
+char *proc_alias[]     = { "afteronly", NULL };
+char proc_name[]       = PROC_NAME;
+char proc_purpose[]    = "pass on events about a key only after detected labels are present";
+
+proc_option_t proc_opts[] = {
+     /*  'option character', "long option string", "option argument",
+	 "option description", <allow multiple>, <required>*/
+     {'A',"","label",
+     "label to detect and pass after first detected",0,0},
+     {'n',"","",
+     "do not include match event in output",0,0},
+     {'x',"","",
+     "require all conditions to match (default: any match)",0,0},
+     {'M',"","records",
+     "maximum table size",0,0},
+     //the following must be left as-is to signify the end of the array
+     {' ',"","",
+     "",0,0}
+};
+
+char proc_nonswitch_opts[]    = "LABEL of key to count";
+char *proc_input_types[]    = {"tuple", NULL};
+char *proc_output_types[]    = {"tuple", NULL};
+char *proc_tuple_member_labels[] = {"COUNT", NULL};
+
+typedef struct _key_data_t {
+     uint8_t state;
+} key_data_t;
+
+int prockeystate_state_size = sizeof(key_data_t);
+
+typedef struct _proc_instance_t {
+     int notonmatch;
+     int requireall;
+     wslabel_set_t lset;
+     wslabel_nested_set_t nest;
+     int matchcnt;
+} proc_instance_t;
+
+int prockeystate_instance_size = sizeof(proc_instance_t);
+
+char prockeystate_option_str[]    = "Xxa:A:nN";
+
+int prockeystate_option(void * vproc, void * type_table, int c, const char * str) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+
+     switch(c) {
+     case 'X':
+     case 'x':
+          proc->requireall = 1;
+          break;
+     case 'N':
+     case 'n':
+          proc->notonmatch = 1;
+          break;
+     case 'a':
+     case 'A':
+          if (index(str,'.') == NULL ) {
+               wslabel_set_add(type_table, &proc->lset, str);
+               //its not nested -- consider for tuple container label too
+          }
+          wslabel_nested_search_build(type_table, &proc->nest, str);
+          proc->matchcnt++;
+          break; 
+     }
+
+     return 1;
+}
+
+int prockeystate_init(void * vproc, void * type_table, int hasvalue) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+     if (proc->nest.cnt == 0) {
+          tool_print("must supply -A label to search for");
+          return 0;
+     }
+
+     return 1;
+}
+
+static int nest_search_callback_match(void * vproc, void * vstate,
+                                      wsdata_t * tdata, wsdata_t * member) {
+     return 1;
+}
+
+int container_search(proc_instance_t * proc, wsdata_t * tdata) {
+     int i;
+     int cnt = 0;
+     for (i = 0; i < proc->lset.len; i++) {
+          if (wsdata_check_label(tdata, proc->lset.labels[i])) {
+               cnt++;
+          }
+     }
+     return cnt;
+}
+
+int prockeystate_update(void * vproc, void * vstate, wsdata_t * tdata,
+                        wsdata_t *key) {
+     proc_instance_t * proc = (proc_instance_t*)vproc;
+     key_data_t * kdata = (key_data_t *) vstate;
+
+     if (kdata->state) {
+          return 1;
+     }
+
+     int hit = container_search(proc, tdata);
+
+     if (!hit || proc->requireall) {
+          //check nested
+          hit += tuple_nested_search(tdata, &proc->nest,
+                                    nest_search_callback_match,
+                                    proc, &kdata);
+     }
+
+     if (!hit || (proc->requireall && (hit < proc->matchcnt))) {
+          return 0;
+     }
+     kdata->state = 1;
+
+     if (proc->notonmatch) {
+          return 0;
+     }
+     return 1;
+}
+

--- a/src/procs/proc_pcapin.c
+++ b/src/procs/proc_pcapin.c
@@ -1,0 +1,904 @@
+/*
+
+proc_pcapin.c -- pcap source from network interface or file
+   
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS   
+*/
+#define PROC_NAME "pcapin"
+//#define DEBUG 1
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/ip6.h>
+#include <netinet/tcp.h>
+#include <netinet/if_ether.h>
+#include <net/ethernet.h>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pcap.h>
+#include "waterslide.h"
+#include "waterslidedata.h"
+#include "procloader.h"
+#include "sysutil.h"
+#include "timeparse.h"
+#include "wstypes.h"
+#include "datatypes/wsdt_tuple.h"
+#include "mimo.h"
+#include "evahash64.h"
+#include "wstuple_ip.h"
+
+char proc_name[]	= PROC_NAME;
+char *proc_tags[]	= { "input", NULL };
+char proc_purpose[]	= "Read pcap from files or interface";
+char *proc_synopsis[]	= {"pcapin <BPF> [-i interface]", NULL};
+char proc_description[]	= "Reads in packet data from file or interface.\n" \
+                            "If no iterface is specified, it will read from pcap from stdin";
+proc_example_t proc_examples[]	= {
+     {NULL, NULL}
+};
+char *proc_alias[]  = {"pcap", "pcap_in", NULL};
+char proc_version[] = "1.0";
+char proc_requires[]     = "";
+char *proc_input_types[]	= {"tuple", NULL};
+char *proc_output_types[]     = {"tuple", NULL};
+proc_port_t proc_input_ports[]     = {{NULL, NULL}};
+char *proc_tuple_container_labels[]     = {NULL};
+char *proc_tuple_conditional_container_labels[]   = {NULL};
+char *proc_tuple_member_labels[]	= {NULL};
+proc_option_t proc_opts[] = {
+     /*  'option character', "long option string", "option argument",
+         "option description", <allow multiple>, <required>*/
+     {'i',"","interface",
+     "read from interface",0,0},
+     {'r',"","file",
+     "read a single file ('-' for stdin)",0,0},
+     {'g',"","",
+     "label CLIENT or SERVER based on low port",0,0},
+     {' ',"","",
+     "",0,0}
+};
+char proc_nonswitch_opts[]	= "specify a BPF packet filter";
+
+#define DEFAULT_SNAPLEN (16384)
+#define RING_BUFFER_SIZE (256*DEFAULT_SNAPLEN)
+
+// processing module instance data structure
+typedef struct _proc_instance_t {
+     uint64_t meta_process_cnt;
+     uint64_t badline_cnt;
+     uint64_t outcnt;
+
+     char error_buffer[PCAP_ERRBUF_SIZE];
+     pcap_t * handler;
+     char * iface_name;
+     char * bpf_string;
+     struct bpf_program bpfp;
+	int bpf_compiled;
+     int linktype;
+     uint32_t link_layer_length;
+
+     wslabel_t * label_datetime;
+     wslabel_t * label_pcap;
+     wslabel_t * label_pkt;
+     wslabel_t * label_pktlen;
+     wslabel_t * label_origpktlen;
+     wslabel_t * label_srcmac;
+     wslabel_t * label_dstmac;
+     wslabel_t * label_ethtype;
+     wslabel_t * label_ip_version;
+     wslabel_t * label_ip_length;
+     wslabel_t * label_ip_proto;
+     wslabel_t * label_ip_src;
+     wslabel_t * label_ip_dst;
+     wslabel_t * label_ip_ttl;
+     wslabel_t * label_ipv4;
+     wslabel_t * label_ipv6;
+     wslabel_t * label_tcp;
+     wslabel_t * label_udp;
+     wslabel_t * label_icmp;
+     wslabel_t * label_srcport;
+     wslabel_t * label_dstport;
+     wslabel_t * label_content;
+     wslabel_t * label_contentlen;
+     wslabel_t * label_biflow;
+     wslabel_t * label_dirflow;
+     wslabel_t * label_flags;
+     wslabel_t * label_syn;
+     wslabel_t * label_synack;
+     wslabel_t * label_ack;
+     wslabel_t * label_fin;
+     wslabel_t * label_rst;
+     wslabel_t * label_push;
+     wslabel_t * label_urgent;
+     wslabel_t * label_truncated;
+     wslabel_t * label_tcpseq;
+     wslabel_t * label_tcpack;
+     wslabel_t * label_empty;
+     wslabel_t * label_client;
+     wslabel_t * label_server;
+     wslabel_t * label_tcpmss;
+     ws_outtype_t * outtype_tuple;
+
+     int guess_server;
+
+     char * single_filename;
+     int done_multifile;
+     int multifile;
+	char * filename;
+} proc_instance_t;
+
+//function prototypes for local functions
+static int proc_cmd_options(int, char **, proc_instance_t *, void *);
+// file
+// stdin and list of files
+static int data_source(void *, wsdata_t*, ws_doutput_t*, int);
+
+#define PCAP_FILENAME_MAX 1024
+static int read_stdin_filename(proc_instance_t * proc) {
+	char buf[PCAP_FILENAME_MAX +1];
+	int len;
+
+	if (proc->handler) {
+		//close
+		pcap_close(proc->handler);
+		proc->handler = NULL;
+	}
+
+	while (fgets(buf, PCAP_FILENAME_MAX, stdin)) {
+          dprint("buf: %s", buf);
+          //strip return
+          len = strlen(buf);
+          if (buf[len - 1] == '\n') {
+               buf[len - 1] = '\0';
+               len--;
+          }
+          proc->filename = buf; // includes null terminator
+          dprint("proc->filename: %s", proc->filename);
+          proc->handler = pcap_open_offline(proc->filename, proc->error_buffer);
+
+		if (proc->handler) {
+               tool_print("opened pcap file %s", buf);
+			if (proc->bpf_compiled) {
+				if (pcap_setfilter(proc->handler, &proc->bpfp) == -1) {
+					fprintf(stderr, "Couldn't install filter %s: %s\n",
+						   proc->bpf_string, pcap_geterr(proc->handler));
+				}
+			}
+
+               return 1;
+		}
+		else {
+			tool_print("ERROR opening pcap file %s", proc->error_buffer);
+		}
+     }
+     proc->done_multifile = 1;
+	return 0;
+
+}
+// The following is a function to take in command arguments and initalize
+// this processor's instance, and is called only once for each instance of this
+// processor.
+// also register as a source here..
+// return 1 if ok
+// return 0 if fail
+int proc_init(wskid_t * kid, int argc, char ** argv, void ** vinstance, 
+              ws_sourcev_t * sv, void * type_table) {
+
+     //allocate proc instance of this processor
+     proc_instance_t * proc =
+          (proc_instance_t*)calloc(1,sizeof(proc_instance_t));
+     *vinstance = proc;
+
+     proc->label_datetime = wsregister_label(type_table, "DATETIME");
+     proc->label_pcap = wsregister_label(type_table, "PCAP");
+     proc->label_pkt = wsregister_label(type_table, "PACKET");
+     proc->label_truncated = wsregister_label(type_table, "TRUNCATED");
+     proc->label_pktlen = wsregister_label(type_table, "PACKETLEN");
+     proc->label_origpktlen = wsregister_label(type_table, "ORIGPACKETLEN");
+     proc->label_srcmac = wsregister_label(type_table, "SRCMAC");
+     proc->label_dstmac = wsregister_label(type_table, "DSTMAC");
+     proc->label_ethtype = wsregister_label(type_table, "ETHTYPE");
+     proc->label_ip_version = wsregister_label(type_table, "IP_VERSION");
+     proc->label_ip_length = wsregister_label(type_table, "IP_LENGTH");
+     proc->label_ip_proto = wsregister_label(type_table, "IP_PROTO");
+     proc->label_ip_src = wsregister_label(type_table, "SRCIP");
+     proc->label_ip_dst = wsregister_label(type_table, "DSTIP");
+     proc->label_ip_ttl = wsregister_label(type_table, "IPTTL");
+     proc->label_ipv4 = wsregister_label(type_table, "IPV4");
+     proc->label_ipv6 = wsregister_label(type_table, "IPV6");
+     proc->label_tcp = wsregister_label(type_table, "TCP");
+     proc->label_udp = wsregister_label(type_table, "UDP");
+     proc->label_icmp = wsregister_label(type_table, "ICMP");
+     proc->label_srcport = wsregister_label(type_table, "SRCPORT");
+     proc->label_dstport = wsregister_label(type_table, "DSTPORT");
+     proc->label_content = wsregister_label(type_table, "CONTENT");
+     proc->label_contentlen = wsregister_label(type_table, "CONTENTLEN");
+     proc->label_biflow = wsregister_label(type_table, "BIFLOW");
+     proc->label_dirflow = wsregister_label(type_table, "DIRFLOW");
+     proc->label_flags = wsregister_label(type_table, "FLAGS");
+     proc->label_syn = wsregister_label(type_table, "SYN");
+     proc->label_synack = wsregister_label(type_table, "SYNACK");
+     proc->label_ack = wsregister_label(type_table, "ACK");
+     proc->label_fin = wsregister_label(type_table, "FIN");
+     proc->label_rst = wsregister_label(type_table, "RST");
+     proc->label_push = wsregister_label(type_table, "PUSH");
+     proc->label_urgent = wsregister_label(type_table, "URG");
+     proc->label_tcpseq = wsregister_label(type_table, "TCPSEQ");
+     proc->label_tcpack = wsregister_label(type_table, "TCPACK");
+     proc->label_empty = wsregister_label(type_table, "NOCONTENT");
+     proc->label_client = wsregister_label(type_table, "CLIENT");
+     proc->label_server = wsregister_label(type_table, "SERVER");
+     proc->label_tcpmss = wsregister_label(type_table, "TCPMSS");
+
+     int checkfilter = 0;
+
+     // initialize flags and variables
+     //read in command options
+     if (!proc_cmd_options(argc, argv, proc, type_table)) {
+          return 0;
+     }
+
+     if (proc->iface_name) {
+          proc->handler = pcap_create(proc->iface_name, proc->error_buffer);
+
+          //pcap_set_rfmon(handler, 1);  //capture wifi packets more broadly
+          pcap_set_promisc(proc->handler, 1); /* Capture packets that are not yours */
+          pcap_set_snaplen(proc->handler, DEFAULT_SNAPLEN); /* Snapshot length */
+          pcap_set_timeout(proc->handler, 1000); /* Timeout in milliseconds */
+          checkfilter = 1;
+          
+     }
+     else if (proc->single_filename) {
+          tool_print("reading from file %s", proc->single_filename);
+          proc->handler = pcap_open_offline(proc->single_filename, proc->error_buffer);
+          //tool_print("interface name not specified - Error");
+          //return 0;
+          checkfilter = 1;
+     }
+     else {
+          proc->multifile = 1;
+          if (!read_stdin_filename(proc)) {
+               return 0;
+          }
+     }
+     if (!proc->handler) {
+          tool_print("ERROR %s", proc->error_buffer);
+          return 0;
+     }
+
+     
+     if(proc->iface_name) {
+          if ((pcap_set_buffer_size(proc->handler, RING_BUFFER_SIZE))!=0) {
+               printf("ERROR on pcap set buffer size\n");
+               exit(-1);
+          }
+
+          int ret = pcap_activate(proc->handler);  //start collection
+          if (ret) {
+               pcap_perror(proc->handler, "pcapin activate");
+               tool_print("ERROR on pcap activation %d\n", ret);
+               exit(-1);
+          }
+     }
+     if (checkfilter && proc->bpf_string)  {
+          if (pcap_compile(proc->handler, &proc->bpfp, proc->bpf_string, 0, PCAP_NETMASK_UNKNOWN) == -1) {
+               fprintf(stderr, "Couldn't parse filter %s: %s\n",
+                       proc->bpf_string, pcap_geterr(proc->handler));
+               return(2);
+          }
+		else {
+			proc->bpf_compiled = 1;
+		}
+          if (pcap_setfilter(proc->handler, &proc->bpfp) == -1) {
+               fprintf(stderr, "Couldn't install filter %s: %s\n",
+                  proc->bpf_string, pcap_geterr(proc->handler));
+               return(2);
+          }
+     }
+
+
+     proc->linktype = pcap_datalink(proc->handler);
+     switch(proc->linktype) {
+     case DLT_EN10MB:
+          proc->link_layer_length = sizeof(struct ether_header);
+          break;
+     default:
+          tool_print("setting no link layer %d", proc->linktype);
+          proc->link_layer_length = 0;
+     }
+
+     /*if (pcap_setnonblock(handler, 1, error_buffer) != 0) {
+       pcap_perror(handler, "setnonblock");
+       printf("ERROR on nonblock %s", error_buffer);
+       }*/
+
+     // TODO: If no input stream is given, we should gracefully exit ...
+     
+     // register sources, set output types
+     proc->outtype_tuple = 
+	     ws_register_source_byname(type_table, "TUPLE_TYPE", data_source, sv);
+
+     if (!proc->outtype_tuple) {
+          fprintf(stderr, "waterslide source registration failed\n");
+          return 0;
+     }
+
+     return 1; 
+}
+
+// Process options from command line
+static int proc_cmd_options(int argc, char ** argv, 
+                             proc_instance_t * proc, void * type_table) {
+
+     int op;
+     // qty of labels provided on cmd line for members parsed from input events
+
+     while ((op = getopt(argc, argv, "r:gGi:")) != EOF) {
+          switch (op) {
+          case 'r':
+               proc->single_filename = strdup(optarg);
+               break;
+          case 'g':
+          case 'G':
+               proc->guess_server = 1;
+               break;
+          case 'i': // use first element in event as container label
+               proc->iface_name = strdup(optarg);
+               break;
+          default:
+               return 0;
+          }
+     }
+     // store all remaining command line tokens as labels for members parsed
+     // from the events received as input
+     while (optind < argc) {
+          // proc->lset is limited to 128 by WSMAX_LABEL_SET defined in waterslide.h
+          int olen = strlen(argv[optind]);
+          if (proc->bpf_string) {
+               int blen = strlen(proc->bpf_string);
+               proc->bpf_string = realloc(proc->bpf_string, olen + blen + 2);
+               proc->bpf_string[blen] = ' ';
+               memcpy(proc->bpf_string + blen + 1, argv[optind], olen);
+               proc->bpf_string[blen + olen + 1] = 0;
+          }
+          else {
+               proc->bpf_string = strdup(argv[optind]);
+          }
+
+	  //TODO aggregate bpf into single string
+          optind++;
+     }
+     
+     return 1;
+}
+
+// this function needs to decide on processing function based on datatype
+// given.. also set output types as needed (unless a sink)
+//return 1 if ok
+// return 0 if problem
+proc_process_t proc_input_set(void * vinstance, wsdatatype_t * input_type,
+                              wslabel_t * port,
+                              ws_outlist_t* olist, int type_index,
+                              void * type_table) {
+     return NULL;
+}
+
+static inline int add_ipv6(wsdata_t * tdata,
+                           void * ipbuf, wslabel_t* label) {
+     char out[INET6_ADDRSTRLEN];
+     const char* result = inet_ntop(AF_INET6, ipbuf, out, sizeof(out));
+     if (!result) {
+          return 0;
+     }
+     tuple_dupe_string(tdata, label, result, strlen(result));
+     return 1;
+}
+
+
+static void add_flow_hashes(proc_instance_t * proc, wsdata_t * tdata, void * ipaddr,
+                            int ipaddrlen, uint16_t srcport, uint16_t dstport,
+                            uint8_t ipproto) {
+
+     uint8_t base[(INET6_ADDRSTRLEN * 2) + 4 + 1];
+
+     int addroffset = ipaddrlen/2;
+     void * srcaddr = ipaddr;
+     void * dstaddr = ipaddr + addroffset;
+
+     int dir = 0;  //client to server
+     if (srcport > dstport) {
+          dir = 1;
+     }
+     else if ((srcport == dstport) && 
+              (memcmp(srcaddr, dstaddr, addroffset) > 0) ) {
+          dir = 1;
+     }
+
+     int blen = ipaddrlen + 5;
+
+     memcpy(base, ipaddr, ipaddrlen);
+     memcpy(base + ipaddrlen, &srcport, 2);
+     memcpy(base + ipaddrlen+2, &dstport, 2);
+     base[ipaddrlen + 4] = ipproto;
+    
+     //hash base.. 
+     uint64_t hash = evahash64(base, blen, 0xDEADBEEF);
+     tuple_member_create_uint64(tdata, hash,
+                                proc->label_dirflow);
+
+     if (dir) {
+          memcpy(base, dstaddr, addroffset);
+          memcpy(base + addroffset, srcaddr, addroffset);
+          memcpy(base + ipaddrlen, &dstport, 2);
+          memcpy(base + ipaddrlen+2, &srcport, 2);
+          hash = evahash64(base, blen, 0xDEADBEEF);
+     }
+     tuple_member_create_uint64(tdata, hash,
+                                proc->label_biflow);
+
+}
+
+static int parse_udp(proc_instance_t * proc, wsdata_t * tdata,
+                     char * buf, uint16_t buflen, uint16_t udpremain,
+                     void * ipaddr, int ipaddrlen,
+                     wsdata_t * wspkt) {
+     if (buflen < 8) {
+          return 0;
+     }
+     wsdata_add_label(tdata, proc->label_udp);
+
+     uint16_t srcport = ntohs(*(uint16_t*)buf);
+     uint16_t dstport = ntohs(*(uint16_t*)(buf+2));
+     uint16_t ulen = ntohs(*(uint16_t*)(buf+4));
+     tuple_member_create_uint16(tdata, srcport,
+                                proc->label_srcport);
+     tuple_member_create_uint16(tdata, dstport,
+                                proc->label_dstport);
+
+     if (proc->guess_server) {
+          if (srcport <= dstport) {
+               wsdata_add_label(tdata, proc->label_server);
+          }
+          else {
+               wsdata_add_label(tdata, proc->label_client);
+          }
+     }
+
+     add_flow_hashes(proc, tdata, ipaddr, ipaddrlen, srcport, dstport,
+                     IPPROTO_UDP);
+     if (ulen < 8) {
+          return 0;
+     }
+     uint16_t clen = ulen - 8;
+     tuple_member_create_uint16(tdata, clen,
+                                proc->label_contentlen);
+
+     if (clen == 0) {
+          dprint("empty");
+          wsdata_add_label(tdata, proc->label_empty);
+     }
+     else if (buflen > 8) {
+          uint16_t remain = buflen - 8; 
+          if (clen <= remain) {
+               tuple_member_create_dep_binary(tdata, wspkt, proc->label_content,
+                                              buf+8, clen);
+          }
+          else {
+               //display truncated data
+               tuple_member_create_dep_binary(tdata, wspkt, proc->label_content,
+                                              buf+8, remain);
+          }
+     }
+     return 1;
+}
+static int parse_tcp(proc_instance_t * proc, wsdata_t * tdata,
+                     char * buf, uint16_t buflen, uint16_t tcpremain,
+                     void * ipaddr, int ipaddrlen,
+                     wsdata_t * wspkt) {
+
+     dprint("parse_tcp %d %d", buflen, ipaddrlen);
+     if (buflen < 20) {
+          return 0;
+     }
+
+     wsdata_add_label(tdata, proc->label_tcp);
+
+     struct tcphdr * thead = (struct tcphdr *)buf;
+
+     uint16_t srcport = ntohs(thead->th_sport);
+     uint16_t dstport = ntohs(thead->th_dport);
+     tuple_member_create_uint16(tdata, srcport,
+                                proc->label_srcport);
+     tuple_member_create_uint16(tdata, dstport,
+                                proc->label_dstport);
+     tuple_member_create_uint(tdata, ntohl(thead->th_seq),
+                              proc->label_tcpseq);
+     tuple_member_create_uint(tdata, ntohl(thead->th_ack),
+                              proc->label_tcpack);
+     tuple_member_create_uint16(tdata, thead->th_flags,
+                                proc->label_flags);
+
+     if (proc->guess_server) {
+          if (srcport <= dstport) {
+               wsdata_add_label(tdata, proc->label_server);
+          }
+          else {
+               wsdata_add_label(tdata, proc->label_client);
+          }
+     }
+
+     if (thead->th_flags & TH_SYN) {
+          if (thead->th_flags & TH_ACK) {
+               wsdata_add_label(tdata, proc->label_synack);
+          }
+          else {
+               wsdata_add_label(tdata, proc->label_syn);
+          }
+     }
+     else if (thead->th_flags & TH_ACK) {
+          wsdata_add_label(tdata, proc->label_ack);
+     }
+     if (thead->th_flags & TH_FIN) {
+          wsdata_add_label(tdata, proc->label_fin);
+     }
+     if (thead->th_flags & TH_RST) {
+          wsdata_add_label(tdata, proc->label_rst);
+     }
+     if (thead->th_flags & TH_PUSH) {
+          wsdata_add_label(tdata, proc->label_push);
+     }
+     if (thead->th_flags & TH_URG) {
+          wsdata_add_label(tdata, proc->label_urgent);
+     }
+
+     //flow hash
+     add_flow_hashes(proc, tdata, ipaddr, ipaddrlen, srcport, dstport, IPPROTO_TCP);
+
+     uint16_t tcphlen = thead->th_off * 4;
+     dprint("tcp buf %d, tcphlen %u", buflen, tcphlen);
+     if (tcphlen < 20) {
+          return 0;
+     }
+     if (tcphlen > buflen) {
+          return 0;
+     }
+
+     if (tcphlen > 20) {
+          //ok we have options
+          int remainder = tcphlen - 20;
+          uint8_t * optbuf = (uint8_t*)buf + 20;
+          while(remainder > 0) {
+               switch(optbuf[0]) {
+               case 1: // NOOP
+                    optbuf++;
+                    remainder--;
+                    break;
+               case 2:
+                   if (remainder >= 4) {
+                        if (optbuf[1] == 4) { 
+                             uint16_t mss = (optbuf[2]<<8) + optbuf[3];
+                             tuple_member_create_uint16(tdata, mss,
+                                                        proc->label_tcpmss);
+                        }
+                        remainder -= optbuf[1];
+                        optbuf += optbuf[1];
+                   }
+                   else {
+                        remainder = 0;
+                   }
+                   break;
+               default:
+                   if (remainder >= 2) {
+                        if (optbuf[1] && (optbuf[1] <= remainder)) {
+                             remainder -= optbuf[1];
+                             optbuf += optbuf[1];
+                        }
+                        else {
+                             remainder = 0;
+                        }
+                   }
+                   else {
+                        remainder = 0;
+                   }
+               }
+          }
+
+     }
+
+     uint16_t clen = buflen - tcphlen;
+     if (buflen < tcpremain) {
+          //display true length rather than truncated length
+          tuple_member_create_uint16(tdata, tcpremain - tcphlen,
+                                     proc->label_contentlen);
+     }
+     else {
+          tuple_member_create_uint16(tdata, clen,
+                                     proc->label_contentlen);
+     }
+
+     if (clen == 0) {
+          wsdata_add_label(tdata, proc->label_empty);
+     }
+     else {
+          tuple_member_create_dep_binary(tdata, wspkt, proc->label_content,
+                                         buf+tcphlen, clen);
+     }
+
+     return 1;     
+}
+
+static int parse_ipv6(proc_instance_t * proc, wsdata_t * tdata,
+                     char * buf, int buflen, wsdata_t * wspkt) {
+     if (buflen < 40) {
+          return 0;
+     }
+     wsdata_add_label(tdata, proc->label_ipv6);
+     struct ip6_hdr * iphead = (struct ip6_hdr *)buf;
+
+     uint16_t plen = ntohs(iphead->ip6_plen);
+     tuple_member_create_uint16(tdata,
+                                plen + 40,
+                                proc->label_ip_length);
+     tuple_member_create_uint16(tdata, 
+                                iphead->ip6_nxt,
+                                proc->label_ip_proto);
+     tuple_add_ipv6(tdata, &iphead->ip6_src, proc->label_ip_src);
+     tuple_add_ipv6(tdata, &iphead->ip6_dst, proc->label_ip_dst);
+
+     tuple_member_create_uint(tdata,
+                              iphead->ip6_hlim,
+                              proc->label_ip_ttl);
+     int remainder;
+     if ((buflen - 40) < plen) {
+          wsdata_add_label(tdata, proc->label_truncated);
+          dprint("buflen = %d, plen = %u", buflen, plen);
+          remainder = buflen - 40;
+     }
+     else {
+          remainder = plen;
+     }
+     if (!remainder) {
+          return 0;
+     }
+     char * next = buf + 40;
+
+     //parse next header .... TODO
+     switch(iphead->ip6_nxt) {
+     case IPPROTO_TCP:
+          parse_tcp(proc, tdata, next, remainder, plen, &iphead->ip6_src, 32, wspkt);
+          break;
+     case IPPROTO_UDP:
+          parse_udp(proc, tdata, next, remainder, plen, &iphead->ip6_src, 32, wspkt);
+          break;
+     default:
+          //nothing
+          break;
+     }
+
+     return 1;
+}
+
+static int parse_ip(proc_instance_t * proc, wsdata_t * tdata,
+                     char * buf, int buflen, wsdata_t * wspkt) {
+     if (buflen < 20) {
+          return 0;
+     }
+     struct ip * iphead = (struct ip *)buf;
+
+     if ((iphead->ip_v == 4) || (iphead->ip_v == 6)) {
+          tuple_member_create_uint16(tdata, iphead->ip_v,
+                                     proc->label_ip_version);
+     }
+     if (iphead->ip_v == 6) {
+          return parse_ipv6(proc, tdata, buf, buflen, wspkt);
+     }
+
+     wsdata_add_label(tdata, proc->label_ipv4);
+     uint16_t iplen = ntohs(iphead->ip_len);
+     uint16_t iphlen = iphead->ip_hl * 4;
+     
+     tuple_member_create_uint16(tdata,
+                                iplen,
+                                proc->label_ip_length);
+     tuple_member_create_uint16(tdata, iphead->ip_p,
+                                proc->label_ip_proto);
+     tuple_member_create_uint(tdata,
+                              iphead->ip_ttl,
+                              proc->label_ip_ttl);
+     tuple_add_ipv4(tdata, &iphead->ip_src, proc->label_ip_src);
+     tuple_add_ipv4(tdata, &iphead->ip_dst, proc->label_ip_dst);
+
+     dprint("len issues buf %d, ip %d, iph %d", buflen, iplen, iphlen);
+
+     if ((iphlen > iplen) || (buflen < iphlen)) {
+          //unexpected pkt
+          return 0;
+     }
+     uint16_t remainder;
+     uint16_t dremain = iplen - iphlen;
+     if (buflen < iplen) {
+          remainder = buflen - iphlen;
+          wsdata_add_label(tdata, proc->label_truncated);
+     }
+     else {
+          remainder = iplen - iphlen;
+     }
+     if (!remainder) {
+          dprint("len issues %d %d", iplen, iphlen);
+          return 0;
+     }
+     char * next = buf + iphlen;
+
+     switch(iphead->ip_p) {
+     case IPPROTO_TCP:
+          parse_tcp(proc, tdata, next, remainder, dremain, &iphead->ip_src, 8, wspkt);
+          break;
+     case IPPROTO_UDP:
+          parse_udp(proc, tdata, next, remainder, dremain, &iphead->ip_src, 8, wspkt);
+          break;
+     default:
+          //nothing
+          break;
+     }
+
+     return 1;
+} 
+
+// proc processing function assigned to a specific data type in proc_io_init
+//return 1 if output is available
+// return 0 if not output
+//
+static int data_source(void * vinstance, wsdata_t* source_data,
+                       ws_doutput_t * dout, int type_index) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+
+     struct pcap_pkthdr * pkthdr = NULL;
+     struct ether_header * etherhdr = NULL;
+     uint8_t * pktdata = NULL;
+     uint16_t ether_type = 0;
+     uint32_t pktremain = 0;
+     int val = pcap_next_ex(proc->handler, &pkthdr, (const uint8_t **)&pktdata);
+
+     if (val != 1) {
+          if (proc->iface_name) {
+               //no packet yet..
+               return 1;
+          }
+          else if (proc->multifile) {
+			if (!read_stdin_filename(proc)) {
+				return 0;
+			}
+               else {
+                    return 1;
+               }
+		}
+          else {
+               return 0; //single file
+          }
+     }
+     if (!pkthdr || !pktdata) {
+          error_print("unexpected lack of packet and/or headers");
+          return 1;
+     }
+
+     wsdt_ts_t ts;
+     ts.sec = pkthdr->ts.tv_sec;
+     ts.usec = pkthdr->ts.tv_usec;
+     tuple_member_create_ts(source_data, ts, proc->label_datetime);
+
+     uint32_t caplen = pkthdr->caplen;
+
+     wsdata_t * capd = tuple_member_create_uint(source_data, caplen, proc->label_pktlen);
+     if (pkthdr->caplen == pkthdr->len) {
+          tuple_add_member_label(source_data, capd, proc->label_origpktlen);
+     }
+     else {
+          tuple_member_create_uint(source_data, pkthdr->len, proc->label_origpktlen);
+     }
+
+     wsdata_t * wspkt = tuple_dupe_binary(source_data, proc->label_pkt,
+                                          (char *)pktdata, caplen);
+
+     if (!wspkt) {
+          error_print("unable to allocate pkt data");
+          return 1;
+     }
+     wsdata_add_label(source_data, proc->label_pcap);
+     wsdt_binary_t * binpkt = (wsdt_binary_t *)wspkt->data;
+
+     switch(proc->linktype) {
+     case DLT_EN10MB:
+          if (pkthdr->caplen > proc->link_layer_length) {
+               etherhdr = (struct ether_header*)pktdata;
+               tuple_member_create_dep_binary(source_data, wspkt, proc->label_dstmac,
+                                       (char *)etherhdr->ether_dhost, ETHER_ADDR_LEN);
+               tuple_member_create_dep_binary(source_data, wspkt, proc->label_srcmac,
+                                       (char *)etherhdr->ether_shost, 6);
+
+               ether_type = ntohs(etherhdr->ether_type);
+               tuple_member_create_uint16(source_data, ether_type,
+                                              proc->label_ethtype);
+          }
+          else {
+               //TODO label packet as invalid
+          }
+     case DLT_RAW:
+          if (pkthdr->caplen >= 20) {
+               if (pktdata[0] == 0x45) {
+                    ether_type = ETHERTYPE_IP;
+               }
+               else if ((pktdata[0] & 0xF0) == 0x60) {
+                    ether_type = ETHERTYPE_IPV6;
+               }
+          }
+          break;
+     default:
+          //TODO Something wiht other linktypes
+          break;
+     }
+
+     if (pkthdr->caplen > proc->link_layer_length) {
+          pktremain = pkthdr->caplen - proc->link_layer_length;
+
+          //check if IP is next
+          switch (ether_type) {
+               case ETHERTYPE_IP:
+                   parse_ip(proc, source_data,
+                            binpkt->buf + proc->link_layer_length, pktremain, wspkt);
+                   break;
+               case ETHERTYPE_IPV6:
+                   parse_ipv6(proc, source_data, binpkt->buf +
+                              proc->link_layer_length, pktremain, wspkt);
+                   break;
+               default:
+                   //TODO Something with other ether types
+                   dprint("link next %x", ether_type);
+                   break;
+          }
+     }
+     ws_set_outdata(source_data, proc->outtype_tuple, dout);
+     proc->meta_process_cnt++;
+
+     return 1;
+}
+
+//return 1 if successful
+//return 0 if no..
+int proc_destroy(void * vinstance) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     tool_print("meta_proc cnt %" PRIu64, proc->meta_process_cnt);
+     tool_print("badline cnt %" PRIu64, proc->badline_cnt);
+     tool_print("output cnt %" PRIu64, proc->outcnt);
+
+
+     //free dynamic allocations
+     free(proc);
+
+     return 1;
+}
+

--- a/src/procs/proc_periodic.c
+++ b/src/procs/proc_periodic.c
@@ -1,0 +1,419 @@
+/*
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+*/
+//finds periodic keys
+
+// test by doing pings
+//     ping www.google.com -i 1.35
+// "pcap_in -i eth0 | tuplehash -o SRCIP DSTIP -L FOO | periodic FOO | print -TV"
+
+
+#define PROC_NAME "periodic"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <math.h>
+#include "waterslide.h"
+#include "waterslidedata.h"
+#include "datatypes/wsdt_tuple.h"
+#include "datatypes/wsdt_uint.h"
+#include "datatypes/wsdt_double.h"
+#include "datatypes/wsdt_ts.h"
+#include "procloader_keystate.h"
+#include "evahash64_data.h"
+#include "sysutil.h"
+
+int is_prockeystate = 1;
+
+char proc_version[]     = "1.1";
+char *proc_alias[]     = { NULL };
+char proc_name[]       = PROC_NAME;
+char proc_purpose[]    = "detect periodic instances per key, assumes DATETIME is available";
+
+proc_option_t proc_opts[] = {
+     /*  'option character', "long option string", "option argument",
+	 "option description", <allow multiple>, <required>*/
+     {'b',"","bins",
+     "number of reference bins per key (default: 4)",0,0},
+     {'c',"","count",
+     "number of observations before reporting results (default: 4)",0,0},
+     {'t',"","milliseconds",
+     "minimum time delta (default: 500ms)",0,0},
+     {'T',"","milliseconds",
+     "maximum time delta",0,0},
+     {'x',"","double",
+     "threshold scaling factor (default: 0.7)",0,0},
+     {'y',"","double",
+     "threshold slope factor (default: 0.25)",0,0},
+     {'M',"","records",
+     "maximum table size",0,0},
+     {'L',"","label",
+     "record periodic time difference as label",0,0},
+     //the following must be left as-is to signify the end of the array
+     {' ',"","",
+     "",0,0}
+};
+
+char proc_nonswitch_opts[]    = "LABEL of key to find periodicity";
+char *proc_input_types[]    = {"tuple", NULL};
+char *proc_output_types[]    = {"tuple", NULL};
+char *proc_tuple_member_labels[] = {"PERIOD", "PERIOD_COUNT", NULL};
+
+
+/// all times in MSEC
+typedef struct _tdelta_bin_t {
+     time_t reference;  
+     time_t threshold;
+     time_t sum; //for averaging
+     uint32_t cnt;
+     struct _tdelta_bin_t * next;
+} tdelta_bin_t;
+
+typedef struct _key_data_t {
+     time_t last;  //in msec
+     tdelta_bin_t * list;   //lru list
+} key_data_t;
+
+int prockeystate_state_size = sizeof(key_data_t);
+
+//indexed by 100 Msec
+#define PRECOMPUTE_LEN (10000)
+#define PRECOMPUTE_MAX (PRECOMPUTE_LEN * 100)
+
+#define THRESH_X  (0.7)
+#define THRESH_Y (0.25)
+
+typedef struct _proc_instance_t {
+     wslabel_t * label_ts;
+     wslabel_t * label_periodic;
+     wslabel_t * label_periodic_count;
+     wslabel_t * label_periodic_threshold;
+     wslabel_t * label_last_tdiff;
+     tdelta_bin_t * freeq;
+     uint32_t minimum_observations;
+     uint32_t bincnt;
+     int min_set;
+     time_t minimum_tdiff;
+     time_t maximum_tdiff;
+     time_t threshold_precompute[PRECOMPUTE_LEN];  //indexed by 100MSEC
+     double thresh_x;
+     double thresh_y;
+     int custom_threshold_factor;
+     uint64_t outoforder;
+} proc_instance_t;
+
+int prockeystate_instance_size = sizeof(proc_instance_t);
+
+proc_labeloffset_t proc_labeloffset[] =
+{
+     {"PERIOD",offsetof(proc_instance_t, label_periodic)},
+     {"PERIOD_COUNT",offsetof(proc_instance_t, label_periodic_count)},
+     {"PERIOD_THRESHOLD",offsetof(proc_instance_t, label_periodic_threshold)},
+     {"LAST_TDIFF",offsetof(proc_instance_t, label_last_tdiff)},
+     {"",0}
+};
+
+char prockeystate_option_str[]    = "x:y:c:C:b:B:t:T:L:";
+
+int prockeystate_option(void * vproc, void * type_table, int c, const char * str) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+
+     switch(c) {
+     case 'x':
+          proc->thresh_x = atof(str);
+          tool_print("adjusted x threshold factor to %f", proc->thresh_x);
+          proc->custom_threshold_factor = 1;
+          break;
+     case 'y':
+          proc->thresh_y = atof(str);
+          tool_print("adjusted y threshold factor to %f", proc->thresh_x);
+          proc->custom_threshold_factor = 1;
+          break;
+     case 'B':
+     case 'b':
+          proc->bincnt = atoi(str);
+          break;
+     case 'C':
+     case 'c':
+          proc->minimum_observations = atoi(str);
+          break;
+     case 't':
+          proc->min_set = 1;
+          proc->minimum_tdiff = atoi(str);
+          break;
+     case 'T':
+          proc->maximum_tdiff = atoi(str);
+          break;
+     case 'L':
+          proc->label_periodic = wsregister_label(type_table, str);
+          break; 
+     }
+
+     return 1;
+}
+
+
+time_t get_threshold(proc_instance_t * proc, time_t delta) {
+     double td = (double) delta * 0.001;
+     double threshold = 1000 * proc->thresh_x * log(proc->thresh_y * (td + 1.0) + 
+                                             (1.0 - proc->thresh_y));
+     return (time_t)threshold;
+}
+time_t get_threshold_optimized(proc_instance_t * proc, time_t delta) {
+     if (delta < PRECOMPUTE_MAX) {
+          time_t dindex = delta / 100;
+          return proc->threshold_precompute[dindex];
+     }
+     return get_threshold(proc, delta);
+}
+
+
+void print_ex_threshold(proc_instance_t * proc, time_t msec) {
+     time_t thr = get_threshold_optimized(proc, msec);
+
+     tool_print("when tdelta is %.3f, threshold is %.3f",
+                (double)msec/1000,
+                (double)thr/1000);
+}
+
+void print_example_thresholds(proc_instance_t * proc) {
+     print_ex_threshold(proc, 500);
+     print_ex_threshold(proc, 2000);
+     print_ex_threshold(proc, 30000);
+     print_ex_threshold(proc, 600000);
+     print_ex_threshold(proc, 1800000);
+     print_ex_threshold(proc, 3600000);
+     print_ex_threshold(proc, 4*3600000);
+     print_ex_threshold(proc, 12*3600000);
+     print_ex_threshold(proc, 24*3600000);
+}
+
+int prockeystate_init(void * vproc, void * type_table, int hasvalue) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+
+     if (!proc->min_set) {
+          proc->minimum_tdiff = 500;
+     }
+     if (!proc->minimum_observations) {
+          proc->minimum_observations = 4;
+     }
+     if (!proc->bincnt) {
+          proc->bincnt = 4;
+     }
+     if (!proc->thresh_x) {
+          proc->thresh_x = THRESH_X;
+     }
+     if (!proc->thresh_y) {
+          proc->thresh_y = THRESH_Y;
+     }
+     proc->label_ts = wssearch_label(type_table, "DATETIME");
+
+     time_t i;
+     for (i = 0; i < PRECOMPUTE_LEN; i++) {
+          proc->threshold_precompute[i] = get_threshold(proc, i * 100 + 50);
+     }
+     if (proc->custom_threshold_factor) {
+          print_example_thresholds(proc);
+     }
+
+     return 1;
+}
+
+static time_t get_datetime_msec(proc_instance_t * proc, wsdata_t * tdata) {
+     wsdata_t ** mset;
+     int mset_len;
+     wsdt_ts_t * ts = NULL;
+     if (tuple_find_label(tdata, proc->label_ts,
+                          &mset_len, &mset)) {
+          if (mset_len && (mset[0]->dtype == dtype_ts)) {
+               //just choose first
+               ts = mset[0]->data;
+               return WSDT_TS_MSEC(ts->sec, ts->usec);
+          }
+     }
+     //get timestamp from clock
+     return 0;
+     
+}
+
+void fill_new_bin(proc_instance_t * proc, key_data_t * kdata,
+                  tdelta_bin_t * bin, time_t tdiff) {
+     if (!bin) {
+          if (proc->freeq) {
+               bin = proc->freeq;
+               proc->freeq = bin->next;
+          }
+          else {
+               bin = malloc(sizeof(tdelta_bin_t));
+               if (!bin) {
+                    return;
+               }
+          }
+     }
+     //memset(bin, 0, sizeof(tdelta_bin_t));
+     bin->next = kdata->list;
+     kdata->list = bin;
+     bin->reference = tdiff;
+     bin->threshold = get_threshold_optimized(proc, tdiff);
+     bin->sum = tdiff;
+     bin->cnt = 1;
+}
+
+int prockeystate_update(void * vproc, void * vstate, wsdata_t * tdata,
+                        wsdata_t *key) {
+     proc_instance_t * proc = (proc_instance_t*)vproc;
+     key_data_t * kdata = (key_data_t *) vstate;
+     time_t current = get_datetime_msec(proc, tdata);
+
+     if (!current) {
+          return 0;
+     }
+     if (!kdata->last) {
+          kdata->last = current;
+          return 0;
+     }
+     if (kdata->last > current) {
+          proc->outoforder++;
+          kdata->last = current;
+          return 0;
+     }
+     time_t tdiff = current - kdata->last;
+     kdata->last = current;
+
+     //ignore certain time differentials
+     if (tdiff < proc->minimum_tdiff) {
+          return 0;
+     }
+     if (proc->maximum_tdiff && (tdiff > proc->maximum_tdiff)) {
+          return 0;
+     }
+
+     int list_len = 0;
+     tdelta_bin_t * prev = NULL;
+
+     tdelta_bin_t * cursor = kdata->list;
+
+     //walk all bins
+     while(cursor) {
+          if ((tdiff + cursor->threshold >= cursor->reference) && 
+              (tdiff <= cursor->threshold + cursor->reference)) {
+               dprint("bin matched");
+               cursor->cnt++;
+               cursor->sum += tdiff;
+               cursor->reference = cursor->sum / (time_t)cursor->cnt;
+
+               //move matched cursor to front of list.. sort most recently used
+               if (prev) {
+                    prev->next = cursor->next;
+                    cursor->next = kdata->list;
+                    kdata->list = cursor;
+               }
+
+               if (cursor->cnt >= proc->minimum_observations) {
+                    tuple_member_create_double(tdata,
+                                               (double)cursor->reference/1000.0,
+                                               proc->label_periodic);
+                    tuple_member_create_uint32(tdata,
+                                               cursor->cnt,
+                                               proc->label_periodic_count);
+                    /*
+                    tuple_member_create_double(tdata,
+                                               (double)cursor->threshold/1000.0,
+                                               proc->label_periodic_threshold);
+                    tuple_member_create_double(tdata,
+                                               (double)tdiff/1000.0,
+                                               proc->label_last_tdiff);
+                                               */
+
+                    return 1;
+               }
+               return 0;
+          }
+          list_len++;
+          if (list_len >= proc->bincnt) {
+               dprint("recycling last element");
+               //recycle last element in list
+               if (prev) {
+                    prev->next = NULL;
+               }
+               else {
+                    kdata->list = NULL;
+               }
+               fill_new_bin(proc, kdata, cursor, tdiff);
+
+               return 0;
+          }
+          prev = cursor;
+          cursor = cursor->next;
+     }
+     //start new bin
+     dprint("starting new bin");
+     fill_new_bin(proc, kdata, NULL, tdiff);
+
+     return 0;
+}
+
+void prockeystate_expire(void * vproc, void * vdata, ws_doutput_t * dout,
+                         ws_outtype_t * outtype_tuple) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+     key_data_t * kd = (key_data_t*)vdata;
+
+     dprint("expiring element");
+
+     //walk list of bins -- recycle them.
+     if (!kd->list) {
+          return;
+     }
+
+     tdelta_bin_t * cursor = kd->list;
+     //find tail of freeq;
+     while (cursor) {
+          if (cursor->next) {
+               cursor = cursor->next;
+          }
+          else {
+               cursor->next = proc->freeq;
+               proc->freeq = kd->list;
+               break;
+          }
+     }
+     kd->list = NULL;
+}
+
+int prockeystate_destroy(void * vproc) {
+     proc_instance_t * proc = (proc_instance_t *)vproc;
+     if (proc->outoforder) {
+          tool_print("events out of order: %"PRIu64, proc->outoforder);
+     }
+
+     tool_print("freeing up freeq: START");
+     tdelta_bin_t * cursor = proc->freeq;
+     tdelta_bin_t * next;
+     while(cursor) {
+          next = cursor->next;
+          free(cursor);
+          cursor = next;
+     }
+     tool_print("freeing up freeq: FINISHED");
+     return 1;
+}

--- a/src/procs/proc_print.c
+++ b/src/procs/proc_print.c
@@ -737,7 +737,7 @@ static void print_json_member(proc_instance_t * proc, wsdata_t * member) {
           wsdt_binary_t * bin = (wsdt_binary_t*)member->data;
           int b;
           for (b = 0; b < bin->len; b++) {
-               fprintf(proc->outfp, "%02u", (uint8_t)bin->buf[b]);
+               fprintf(proc->outfp, "%02x", (uint8_t)bin->buf[b]);
           }
           fprintf(proc->outfp, "\"");
      }

--- a/src/procs/proc_removenest.c
+++ b/src/procs/proc_removenest.c
@@ -1,0 +1,267 @@
+/*
+
+   proc_removenest.c - creates a deep copy of a tuple, removing specified
+   elements in nested structure
+   
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+*/
+//removed members from tuple..
+#define PROC_NAME "removenest"
+//#define DEBUG 1
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "waterslide.h"
+#include "waterslidedata.h"
+#include "waterslide_io.h"
+#include "procloader.h"
+#include "evahash64.h"
+#include "stringhash9a.h"
+#include "datatypes/wsdt_tuple.h"
+
+char proc_version[]     = "1.5";
+char *proc_tags[] = {"Stream Manipulation", NULL};
+char *proc_menus[]     = { "Filters", NULL };
+char *proc_alias[]     = { "nestdelete", "nestremove", NULL};
+char proc_name[]       = PROC_NAME;
+char proc_purpose[]    = "Creates a new tuple, removing specified members";
+char *proc_synopsis[] = { "removenest <LIST_OF_LABELS> [-L <label>]", NULL };
+char proc_description[] = "Creates a deep copy of input tuple while removing specified labeled members of the structure.";
+char proc_requires[] = "";
+
+proc_option_t proc_opts[] = {
+     /*  'option character', "long option string", "option argument",
+	 "option description", <allow multiple>, <required>*/
+     //the following must be left as-is to signify the end of the array
+     {' ',"","",
+     "",0,0}
+};
+char proc_nonswitch_opts[]    = "list of LABELS";
+char *proc_input_types[]    = {"tuple", NULL};
+char *proc_output_types[]    = {"tuple", NULL};
+proc_port_t proc_input_ports[] = {{NULL, NULL}};
+char *proc_tuple_container_labels[] = {NULL};
+char *proc_tuple_conditional_container_labels[] = {NULL};
+char *proc_tuple_member_labels[] = {NULL};
+
+//function prototypes for local functions
+static int process_tuple(void *, wsdata_t*, ws_doutput_t*, int);
+
+typedef struct _proc_instance_t {
+     uint64_t meta_process_cnt;
+     uint64_t outcnt;
+     stringhash9a_t * ignore_table;
+     ws_outtype_t * outtype_tuple;
+     wslabel_nested_set_t nest;
+     uint64_t generation;
+     uint64_t generation_hash;
+} proc_instance_t;
+
+static int proc_cmd_options(int argc, char ** argv, 
+                            proc_instance_t * proc,
+                            void * type_table) {
+     int op;
+
+     while ((op = getopt(argc, argv, "H")) != EOF) {
+          switch (op) {
+          default:
+               return 0;
+          }
+     }
+
+     while (optind < argc) {
+          wslabel_nested_search_build(type_table, &proc->nest, argv[optind]);
+          optind++;
+     }
+
+     return 1;
+}
+
+#define IGNORE_TABLE_SIZE 10000
+
+// the following is a function to take in command arguments and initalize
+// this processor's instance..
+//  also register as a source here..
+// return 1 if ok
+// return 0 if fail
+int proc_init(wskid_t * kid, int argc, char ** argv, void ** vinstance, ws_sourcev_t * sv,
+              void * type_table) {
+     
+     //allocate proc instance of this processor
+     proc_instance_t * proc =
+          (proc_instance_t*)calloc(1,sizeof(proc_instance_t));
+     *vinstance = proc;
+
+     //read in command options
+     if (!proc_cmd_options(argc, argv, proc, type_table)) {
+          return 0;
+     }
+
+     proc->ignore_table = stringhash9a_create(0, IGNORE_TABLE_SIZE);
+     if (!proc->ignore_table) {
+          tool_print("unable to create a stringhash9a table");
+          return 0;
+     }
+
+     if (proc->nest.cnt == 0) {
+          tool_print("must specify tuple items to remove");
+          return 0;
+     }
+   
+     return 1; 
+}
+
+// this function needs to decide on processing function based on datatype
+// given.. also set output types as needed (unless a sink)
+//return 1 if ok
+// return 0 if problem
+proc_process_t proc_input_set(void * vinstance, wsdatatype_t * meta_type,
+                              wslabel_t * port,
+                              ws_outlist_t* olist, int type_index,
+                              void * type_table) {
+     proc_instance_t * proc = (proc_instance_t *)vinstance;
+     if (wsdatatype_match(type_table, meta_type, "TUPLE_TYPE")) {
+          if (!proc->outtype_tuple) {
+               proc->outtype_tuple = ws_add_outtype(olist, dtype_tuple, NULL);
+          }
+          return process_tuple;
+     }
+     return NULL;
+}
+
+static inline uint64_t member_pointer_hash(proc_instance_t * proc, wsdata_t * member) {
+     uint64_t mhash = evahash64((uint8_t *)&member, sizeof(wsdata_t*), 0x1235aade);
+     return (mhash ^ proc->generation_hash);   //xor hashes together
+}
+
+static int nest_ignore_element(void * vproc, void * vevent,
+                               wsdata_t * tdata, wsdata_t * member) {
+     proc_instance_t * proc = (proc_instance_t*)vproc;
+
+     //add pointer member address to hashtable
+     uint64_t phash = member_pointer_hash(proc, member);
+     dprint("found nest element to remove %"PRIu64, phash);
+     stringhash9a_set(proc->ignore_table, &phash, sizeof(uint64_t));
+     return 1;
+}
+
+static inline int is_removed(proc_instance_t * proc, wsdata_t * member) {
+     //check if pointer to member is in remove list
+     uint64_t phash = member_pointer_hash(proc, member);
+     int rtn = stringhash9a_check(proc->ignore_table, &phash, sizeof(uint64_t));
+     dprint("checking if element is to be removed %"PRIu64 " %s", phash, rtn ?  "yes":"no");
+     return rtn;
+}
+
+static int tuple_removal_deep_copy(proc_instance_t * proc, wsdata_t* src, wsdata_t* dst) {
+     wsdt_tuple_t * src_tuple = (wsdt_tuple_t*)src->data;
+     // duplicate container label (not search member labels) ... for hierarchical/nested tuples, these
+     // container labels will wind up being the member search labels for the nested subtuples
+     wsdata_duplicate_labels(src, dst);
+     uint32_t i;
+     int len = src_tuple->len;
+     for (i = 0; i < len; i++) {
+          if (!is_removed(proc, src_tuple->member[i])) {
+               if(src_tuple->member[i]->dtype == dtype_tuple) {
+                    wsdata_t * dst_sub_tuple = wsdata_alloc(dtype_tuple);
+                    if(!dst_sub_tuple) {
+                         return 0;
+                    }
+                    // recursively copy each subtuple
+                    if(!tuple_removal_deep_copy(proc, src_tuple->member[i], dst_sub_tuple)) {
+                         wsdata_delete(dst_sub_tuple);
+                         return 0;
+                    }
+                    // don't assume that add tuple member will always succeed
+                    if(!add_tuple_member(dst, dst_sub_tuple)) {
+                         wsdata_delete(dst_sub_tuple);
+                         return 0;
+                    }
+               }
+               else {
+                    if(!add_tuple_member(dst, src_tuple->member[i])) {
+                         return 0;
+                    }
+               }
+          }
+     }
+     return 1;
+}
+
+
+//// proc processing function assigned to a specific data type in proc_io_init
+static int process_tuple(void * vinstance, wsdata_t* input_data,
+                         ws_doutput_t * dout, int type_index) {
+
+     dprint("removenest process_tuple start");
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+
+     proc->meta_process_cnt++;
+
+     //make hashes unique per tuple
+     proc->generation++;
+     proc->generation_hash = evahash64((uint8_t*)&proc->generation, sizeof(uint64_t), 0x2123fdee);
+
+
+     //check if anything should be removed
+     int found = tuple_nested_search(input_data, &proc->nest,
+                                     nest_ignore_element,
+                                     proc, NULL);
+     if (!found) {
+          ws_set_outdata(input_data, proc->outtype_tuple, dout);
+          proc->outcnt++;
+          dprint("removenest nothing to remove");
+          return 1;
+     }
+
+     //start deep copy
+     wsdata_t * newtupledata = wsdata_alloc(dtype_tuple);
+     if (!newtupledata) {
+          return 1;
+     }
+     wsdata_add_reference(newtupledata);
+
+     tuple_removal_deep_copy(proc, input_data, newtupledata);
+
+     ws_set_outdata(newtupledata, proc->outtype_tuple, dout);
+     wsdata_delete(newtupledata);
+
+     proc->outcnt++;
+     dprint("removenest process_tuple end");
+     return 1;
+}
+
+//return 1 if successful
+//return 0 if no..
+int proc_destroy(void * vinstance) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     tool_print("meta_proc cnt %" PRIu64, proc->meta_process_cnt);
+     tool_print("output cnt %" PRIu64, proc->outcnt);
+
+     //free dynamic allocations
+     if (proc->ignore_table) {
+          stringhash9a_destroy(proc->ignore_table);
+     }
+     free(proc);
+
+     return 1;
+}
+

--- a/src/procs/proc_tls.c
+++ b/src/procs/proc_tls.c
@@ -1,0 +1,908 @@
+/*
+
+proc_tls.c - interpret binary buffer as a TLS frame for decoding
+
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+*/
+#define PROC_NAME "tls"
+//#define DEBUG 1
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <time.h>
+#include <assert.h>
+#include "waterslide.h"
+#include "waterslidedata.h"
+#include "datatypes/wsdt_binary.h"
+#include "datatypes/wsdt_string.h"
+#include "datatypes/wsdt_bigstring.h"
+#include "datatypes/wsdt_mediumstring.h"
+#include "datatypes/wsdt_fixedstring.h"
+#include "datatypes/wsdt_tuple.h"
+#include "datatypes/wsdt_ftype.h"
+#include "procloader.h"
+#include "wstypes.h"
+
+#define MAXJA3 2048
+
+char proc_version[]     = "1.0";
+char proc_requires[]     = "";
+char *proc_menus[]     = { NULL };
+char *proc_tags[]      = { "decoder", NULL };
+char *proc_alias[]     = { "tlsrec", NULL };
+char proc_name[]       = PROC_NAME;
+char proc_purpose[]    = "decode TLS content";
+char *proc_synopsis[]    = {"tls <LABEL>", NULL};
+char proc_description[] = "Decode tls content.\n";
+
+proc_example_t proc_examples[]    = {
+     {"... | tls CONTENT | ...","decode as TLS the tuple member with the label CONTENT "},
+     {NULL,""}
+};
+
+proc_option_t proc_opts[] = {
+     /*  'option character', "long option string", "option argument",
+	 "option description", <allow multiple>, <required>*/
+     {'L',"","label",
+     "label of output buffer",0,0},
+     {'E',"","",
+     "parse extensions",0,0},
+     {'J',"","",
+     "compute JA3",0,0},
+     //the following must be left as-is to signify the end of the array
+     {' ',"","",
+     "",0,0}
+};
+char proc_nonswitch_opts[]    = "LABEL of tuple string member to decode";
+char *proc_input_types[]    = {"tuple", NULL};
+char *proc_output_types[]    = {"tuple", NULL};
+proc_port_t proc_input_ports[]     = {{NULL, NULL}};
+char *proc_tuple_container_labels[]     = {NULL};
+char *proc_tuple_conditional_container_labels[]   = {NULL};
+char *proc_tuple_member_labels[] = {"TLSREC", NULL};
+
+//function prototypes for local functions
+static int proc_process_label(void *, wsdata_t*, ws_doutput_t*, int);
+
+typedef struct _proc_instance_t {
+     uint64_t outcnt;
+
+     ws_outtype_t * outtype_tuple;
+     wslabel_t * label_tls;
+     wslabel_t * label_tlsrec;
+     wslabel_t * label_tlstype;
+     wslabel_t * label_tlsreclen;
+     wslabel_t * label_handshake;
+     wslabel_t * label_clienthello;
+     wslabel_t * label_serverhello;
+     wslabel_t * label_serverdone;
+     wslabel_t * label_finished;
+     wslabel_t * label_clientkey;
+     wslabel_t * label_serverkey;
+     wslabel_t * label_ciphersuites;
+     wslabel_t * label_ciphersuite;
+     wslabel_t * label_major;
+     wslabel_t * label_minor;
+     wslabel_t * label_version;
+     wslabel_t * label_extension;
+     wslabel_t * label_appdata;
+     wslabel_t * label_appdatabuf;
+     wslabel_t * label_encrypted;
+     wslabel_t * label_changecipher;
+     wslabel_t * label_alert;
+     wslabel_t * label_random;
+     wslabel_t * label_sessionid;
+     wslabel_t * label_compression;
+     wslabel_t * label_extensions;
+     wslabel_t * label_ext;
+     wslabel_t * label_extid;
+     wslabel_t * label_extdata;
+     wslabel_t * label_grease;
+     wslabel_t * label_sni;
+     wslabel_t * label_ja3;
+     wslabel_t * label_hellorequest;
+     wslabel_t * label_certificate;
+     wslabel_t * label_certrequest;
+     wslabel_t * label_certverify;
+     wslabel_t * label_truncated;
+     wslabel_t * label_buffer;
+     wslabel_t * label_padding;
+     wslabel_set_t lset;
+
+     int do_extensions;
+     int do_ja3;
+     char jabuf[MAXJA3];
+} proc_instance_t;
+
+static int proc_cmd_options(int argc, char ** argv, 
+                             proc_instance_t * proc,
+                             void * type_table) {
+     int op;
+
+     while ((op = getopt(argc, argv, "eEjJL:")) != EOF) {
+          switch (op) {
+          case 'E':
+          case 'e':
+               proc->do_extensions = 1;
+               break;
+          case 'j':
+          case 'J':
+               proc->do_ja3 = 1;
+               break;
+          case 'L':
+               proc->label_tls = wsregister_label(type_table, optarg);
+               break;
+          default:
+               return 0;
+          }
+     }
+     while (optind < argc) {
+          wslabel_set_add(type_table, &proc->lset, argv[optind]);
+          tool_print("searching for string with label %s",
+                     argv[optind]);
+          optind++;
+     }
+     return 1;
+}
+
+// the following is a function to take in command arguments and initalize
+// this processor's instance..
+//  also register as a source here..
+// return 1 if ok
+// return 0 if fail
+int proc_init(wskid_t * kid, int argc, char ** argv, void ** vinstance, ws_sourcev_t * sv,
+              void * type_table) {
+     
+     //allocate proc instance of this processor
+     proc_instance_t * proc =
+          (proc_instance_t*)calloc(1,sizeof(proc_instance_t));
+     *vinstance = proc;
+
+     proc->label_tls = wsregister_label(type_table, "TLS");
+     proc->label_tlsrec = wsregister_label(type_table, "TLSREC");
+     proc->label_tlstype = wsregister_label(type_table, "TLSTYPE");
+     proc->label_tlsreclen = wsregister_label(type_table, "TLSRECLEN");
+     proc->label_handshake = wsregister_label(type_table, "TLSHANDSHAKE");
+     proc->label_clienthello = wsregister_label(type_table, "CLIENTHELLO");
+     proc->label_serverhello = wsregister_label(type_table, "SERVERHELLO");
+     proc->label_serverdone = wsregister_label(type_table, "SERVERDONE");
+     proc->label_finished = wsregister_label(type_table, "TLSFINISHED");
+     proc->label_clientkey = wsregister_label(type_table, "CLIENTKEY");
+     proc->label_serverkey = wsregister_label(type_table, "SERVERKEY");
+     proc->label_ciphersuites = wsregister_label(type_table, "CIPHERSUITES");
+     proc->label_ciphersuite = wsregister_label(type_table, "CIPHERSUITE");
+     proc->label_major = wsregister_label(type_table, "TLSMAJORVERSION");
+     proc->label_minor = wsregister_label(type_table, "TLSMINORVERSION");
+     proc->label_version = wsregister_label(type_table, "CLIENTVERSION");
+     proc->label_extension = wsregister_label(type_table, "EXTENSION");
+     proc->label_appdata = wsregister_label(type_table, "TLSAPPDATA");
+     proc->label_appdatabuf = wsregister_label(type_table, "APPDATABUF");
+     proc->label_encrypted = wsregister_label(type_table, "ENCRYPTED");
+     proc->label_changecipher = wsregister_label(type_table, "CHANGECIPHER");
+     proc->label_buffer = wsregister_label(type_table, "BUFFER");
+     proc->label_alert = wsregister_label(type_table, "TLSALERT");
+     proc->label_random = wsregister_label(type_table, "RANDOM");
+     proc->label_sessionid = wsregister_label(type_table, "SESSIONID");
+     proc->label_compression = wsregister_label(type_table, "COMPRESSION");
+     proc->label_extensions = wsregister_label(type_table, "EXTENSIONS");
+     proc->label_ext = wsregister_label(type_table, "EXTENSION");
+     proc->label_extid = wsregister_label(type_table, "ID");
+     proc->label_extdata = wsregister_label(type_table, "DATA");
+     proc->label_grease = wsregister_label(type_table, "GREASE");
+     proc->label_ja3 = wsregister_label(type_table, "JA3");
+     proc->label_sni = wsregister_label(type_table, "SNI");
+     proc->label_hellorequest = wsregister_label(type_table, "HELLOREQUEST");
+     proc->label_certificate = wsregister_label(type_table, "CERTIFICATE");
+     proc->label_certrequest = wsregister_label(type_table, "CERTREQUEST");
+     proc->label_certverify = wsregister_label(type_table, "CERTVERIFY");
+     proc->label_truncated = wsregister_label(type_table, "TRUNCATED");
+     proc->label_padding = wsregister_label(type_table, "PADDING");
+
+     //read in command options
+     if (!proc_cmd_options(argc, argv, proc, type_table)) {
+          return 0;
+     }
+
+     if (!proc->lset.len) {
+          //add a reasonable default
+          wslabel_set_add(type_table, &proc->lset, "CONTENT");
+     }
+     return 1; 
+}
+
+
+// this function needs to decide on processing function based on datatype
+// given.. also set output types as needed (unless a sink)
+//return 1 if ok
+// return 0 if problem
+proc_process_t proc_input_set(void * vinstance, wsdatatype_t * input_type,
+                              wslabel_t * port,
+                              ws_outlist_t* olist, int type_index,
+                              void * type_table) {
+     proc_instance_t * proc = (proc_instance_t *)vinstance;
+
+     if (!wsdatatype_match(type_table, input_type, "TUPLE_TYPE")) {
+          return NULL;  // not matching expected type
+     }
+
+     proc->outtype_tuple =
+          ws_add_outtype(olist, input_type, NULL);
+
+     return proc_process_label; // a function pointer
+}
+
+#define HS_HELLOREQUEST 0
+#define HS_CLIENTHELLO 1
+#define HS_SERVERHELLO 2
+#define HS_CERTIFICATE 11
+#define HS_SERVERKEY 12
+#define HS_CERTREQUEST 13
+#define HS_SERVERDONE 14
+#define HS_CERTVERIFY 15
+#define HS_CLIENTKEY 16
+#define HS_FINISHED 20
+
+#define GREASE_FILTER 0x0a0a
+
+/*
+typedef struct _tls_handshake_t {
+     uint8_t type;
+     uint24_t length;
+} tls_handshake_t;
+*/
+#define CLIENTHELLO_RANDOMLEN (32)
+#define CLIENTHELLO_MIN (2 + CLIENTHELLO_RANDOMLEN + 1)
+
+static inline int get_sni(proc_instance_t * proc,
+                          wsdata_t * tdata, wsdata_t * dep,
+                          uint8_t * buf, int buflen) {
+     while (buflen >= 4) {
+          uint16_t extid = (buf[0]<<8) + buf[1];
+
+          uint16_t extlen = (buf[2]<<8) + buf[3];
+          if (buflen < (extlen + 4)) {
+               return 0;
+          }
+          if ((extid == 0) && (extlen > 5))  {
+               //sni
+               uint16_t listlen = (buf[4]<<8) + buf[5];
+               if (listlen == (extlen - 2)) {
+                    uint8_t sntype = buf[6];
+                    if (sntype == 0) {
+                         uint16_t nlen = (buf[7]<<8) + buf[8];
+                         if (nlen && (nlen == (listlen - 3))) {
+                              tuple_member_create_dep_strdetect(tdata,dep,
+                                                                proc->label_sni,
+                                                                (char *)buf + 9, nlen);
+                              return 1;
+                         }
+                    }
+               }
+          }
+
+
+          buf    += 4 + extlen;
+          buflen -= 4 + extlen;
+     }
+     return 0;
+
+}
+
+
+// registered TLS hello extension types:
+//        http://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml
+static inline int parse_extensions(proc_instance_t * proc,
+                                   wsdata_t * tdata, wsdata_t * dep,
+                                   uint8_t * buf, int buflen) {
+
+     if(buflen < 4) {
+          return 0;
+     }
+
+     //create extension tuple:
+     wsdata_t * extsub = tuple_member_create_wsdata(tdata, dtype_tuple,
+                                                    proc->label_extensions);
+
+     
+     while (buflen >= 4) {
+          uint16_t extid = (buf[0]<<8) + buf[1];
+
+          uint16_t extlen = (buf[2]<<8) + buf[3];
+          if (buflen < (extlen + 4)) {
+               return 0;
+          }
+          wsdata_t * ext = tuple_member_create_wsdata(extsub, dtype_tuple,
+                                                      proc->label_ext);
+
+          if (((extid & GREASE_FILTER) == GREASE_FILTER) &&
+              (buf[0] == buf[1])) {
+               tuple_add_member_label(extsub, ext, proc->label_grease);
+          }
+          else if (extid == 21) {
+               tuple_add_member_label(extsub, ext, proc->label_padding);
+          }
+          tuple_member_create_uint16(ext, extid, proc->label_extid);
+         
+          if (extlen) { 
+               tuple_member_create_dep_binary(ext, dep, proc->label_extdata,
+                                              (char *)buf + 4, extlen);
+          }
+
+          buf    += 4 + extlen;
+          buflen -= 4 + extlen;
+     }
+
+     return 1;
+
+
+}
+
+
+static inline int snprint_uint16_list(char * jabuf, int max,
+                                      uint8_t * buf, int buflen) {
+     int jalen = 0;
+     int i;
+     int hasval = 0;
+
+     for (i = 0; (i + 1) < buflen; i+=2) {
+          //check grease
+          if ((buf[i] == buf[i+1]) && 
+              ((buf[i] & 0xf) == 0xa) && 
+              ((buf[i+1] & 0xf) == 0xa)) {
+               //grease!!
+               dprint("GREASE: %02x%02x",buf[i], buf[i+1]);
+          }
+          else {
+               uint16_t val = (buf[i]<<8) + buf[i+1];
+               if (hasval) {
+                    jalen += snprintf(jabuf + jalen, max - jalen, "-%u", val); 
+               }
+               else {
+                    jalen += snprintf(jabuf + jalen, max - jalen, "%u", val); 
+                    hasval = 1;
+               }
+          }
+     }
+     return jalen;
+}
+
+
+static int make_ja3(proc_instance_t * proc,
+                    wsdata_t * tdata, uint16_t version,
+                    uint8_t * ciphersuites, int cipherlen,
+                    uint8_t * exbuf, int exbuflen) {
+
+     dprint("starting ja3 %u %d %d", version, cipherlen, exbuflen);
+
+     char * jabuf = proc->jabuf; //use preallocated buffer
+     int jalen = 0;
+
+     jalen += snprintf(jabuf + jalen, MAXJA3 - jalen, "%u,", version); 
+
+     jalen += snprint_uint16_list(jabuf + jalen, MAXJA3 - jalen,
+                                  ciphersuites, cipherlen);
+
+     jalen += snprintf(jabuf + jalen, MAXJA3 - jalen, ","); 
+
+     int hasext = 0;
+
+     uint8_t * ecf = NULL;
+     int ecflen = 0;
+
+     uint8_t * ec = NULL;
+     int eclen = 0;
+
+     while (exbuflen >= 4) {
+          uint16_t extid = (exbuf[0]<<8) + exbuf[1];
+
+          uint16_t extlen = (exbuf[2]<<8) + exbuf[3];
+          if (exbuflen < (extlen + 4)) {
+               break;
+          }
+
+          if (((extid & 0x0f0f) == GREASE_FILTER) &&
+              (exbuf[0] == exbuf[1])) {
+               //grease!
+          }
+          else {
+               if (hasext) {
+                    jalen += snprintf(jabuf + jalen, MAXJA3 - jalen, "-%u", extid); 
+               }
+               else {
+                    hasext = 1;
+                    jalen += snprintf(jabuf + jalen, MAXJA3 - jalen, "%u", extid); 
+               }
+
+          }
+          if (extid == 0x000a) {
+               ec = exbuf + 4;
+               eclen = extlen;
+          }
+
+          if (extid == 0x000b) {
+               ecf = exbuf + 4;
+               ecflen = extlen;
+          }
+
+          exbuf    += 4 + extlen;
+          exbuflen -= 4 + extlen;
+     }
+
+     jalen += snprintf(jabuf + jalen, MAXJA3 - jalen, ","); 
+     if (ec && (eclen >2)) {
+          dprint("hasec %d", eclen);
+          int tlen = (ec[0]<<8) + ec[1];
+          if (tlen == (eclen - 2)) {
+               jalen += snprint_uint16_list(jabuf + jalen, MAXJA3 - jalen,
+                                            ec + 2, eclen - 2);
+          }
+     }
+     jalen += snprintf(jabuf + jalen, MAXJA3 - jalen, ","); 
+     if (ecf && (ecflen > 1)) {
+          dprint("hasecf %d %u", ecflen, ecf[0]);
+          int tlen = ecf[0];
+          if (tlen == (ecflen - 1)) {
+               ecf+=1;
+               int i;
+               for (i = 0; i < tlen; i++) {
+                    if (i > 0) {
+                         jalen += snprintf(jabuf + jalen, MAXJA3 - jalen, "-%u",
+                                           ecf[i]); 
+                    } else {
+                         jalen += snprintf(jabuf + jalen, MAXJA3 - jalen, "%u",
+                                           ecf[i]); 
+                    }
+
+               }
+          }
+     }
+
+     //ok time to output string
+     tuple_dupe_string(tdata, proc->label_ja3, jabuf, jalen);
+     return 1;
+}
+
+static inline int parse_clienthello(proc_instance_t * proc,
+                                    wsdata_t * tdata, wsdata_t * dep,
+                                    uint8_t * buf, int buflen) {
+     if (buflen < CLIENTHELLO_MIN) {
+          return 0;
+     } 
+     uint16_t version = (buf[0]<<8) + buf[1];
+     //tuple_member_create_uint16(tdata, version, proc->label_version);
+     tuple_member_create_dep_binary(tdata, dep, proc->label_random,
+                                    (char *)buf+2, CLIENTHELLO_RANDOMLEN);
+
+     uint8_t *offset = buf + 2 + CLIENTHELLO_RANDOMLEN;
+     int offlen = buflen - 2 - CLIENTHELLO_RANDOMLEN;
+
+     if (offlen < 1) {
+          return 0;
+     }
+
+     int sid_len = offset[0];
+
+     if (offlen < (sid_len + 1)) {
+          return 0;
+     }
+
+     if (sid_len) {
+          tuple_member_create_dep_binary(tdata, dep, proc->label_sessionid,
+                                         (char *)offset + 1, sid_len);
+     }
+
+     offset += sid_len + 1;
+     offlen -= sid_len + 1;
+
+     if (offlen < 2) {
+          return 0;
+     }
+
+     int cipherlen = (offset[0]<<8) + offset[1];
+     if (offlen < (cipherlen + 2)) {
+          return 0;
+     }
+
+     uint8_t * ciphersuites = offset + 2;
+     
+     tuple_member_create_dep_binary(tdata, dep, proc->label_ciphersuites,
+                                    (char *)offset + 2, cipherlen);
+
+     offset += 2 + cipherlen;
+     offlen -= 2 + cipherlen;
+
+     if (offlen < 1) {
+          return 0;
+     }
+     int complen = offset[0];
+     if (offlen < (complen + 1)) {
+          return 0;
+     }
+     if ((complen == 1) && (offset[1] == 0)) {
+          //ignore this basic compression setting
+     }
+     else {
+          tuple_member_create_dep_binary(tdata, dep, proc->label_compression,
+                                         (char *)offset + 1, complen);
+     }
+
+     offset += 1 + complen;
+     offlen -= 1 + complen;
+
+     if (offlen < 2) {
+          //no extensions
+          return 1;  //still valid
+     }
+     int extlen = (offset[0]<<8) + (offset[1]);
+     if (offlen < (extlen + 2)) {
+          return 0;
+     }
+     uint8_t * extbuf = offset + 2;
+     /*
+        tuple_member_create_dep_binary(tdata, dep, proc->label_extensions,
+                                    (char *)offset + 2, extlen);
+      */
+
+
+     get_sni(proc, tdata, dep, extbuf, extlen);
+
+     if (proc->do_extensions) {
+          parse_extensions(proc, tdata, dep, extbuf, extlen);
+     }
+
+     if (proc->do_ja3) {
+          make_ja3(proc, tdata, version, ciphersuites, cipherlen, extbuf, extlen);
+     }
+
+     return 1;
+}
+#define SERVERHELLO_MIN (2+32+1+2+1)
+
+static inline int parse_serverhello(proc_instance_t * proc,
+                                    wsdata_t * tdata, wsdata_t * dep,
+                                    uint8_t * buf, int buflen) {
+     if (buflen < SERVERHELLO_MIN) {
+          return 0;
+     } 
+     uint16_t version = (buf[0]<<8) + buf[1];
+     tuple_member_create_uint16(tdata, version, proc->label_version);
+     tuple_member_create_dep_binary(tdata, dep, proc->label_random,
+                                    (char *)buf+2, CLIENTHELLO_RANDOMLEN);
+
+     uint8_t *offset = buf + 2 + CLIENTHELLO_RANDOMLEN;
+     int offlen = buflen - 2 - CLIENTHELLO_RANDOMLEN;
+
+     if (offlen < 1) {
+          return 0;
+     }
+
+     int sid_len = offset[0];
+
+     if (offlen < (sid_len + 1)) {
+          return 0;
+     }
+
+     if (sid_len) {
+          tuple_member_create_dep_binary(tdata, dep, proc->label_sessionid,
+                                         (char *)offset + 1, sid_len);
+     }
+
+     offset += sid_len + 1;
+     offlen -= sid_len + 1;
+
+     if (offlen < 3) {
+          return 0;
+     }
+
+     //uint16_t ciphersuite = (offset[0] << 8) + offset[1];
+     //tuple_member_create_uint16(tdata, ciphersuite, proc->label_ciphersuites);
+
+     
+     tuple_member_create_dep_binary(tdata, dep, proc->label_ciphersuite,
+                                    (char *)offset, 2);
+
+     uint16_t compression = offset[2];
+     tuple_member_create_uint16(tdata, compression, proc->label_compression);
+
+
+     offset += 3;
+     offlen -= 3;
+
+     if (offlen < 2) {
+          //no extensions
+          return 1;  //still valid
+     }
+     int extlen = (offset[0]<<8) + (offset[1]);
+     if (offlen < (extlen + 2)) {
+          return 0;
+     }
+     uint8_t * extbuf = offset + 2;
+
+     if (proc->do_extensions) {
+          parse_extensions(proc, tdata, dep, extbuf, extlen);
+     }
+
+     return 1;
+}
+
+static inline int parse_handshake(proc_instance_t * proc,
+                                  wsdata_t * tdata, wsdata_t * parenttuple, wsdata_t * dep,
+                                  uint8_t * buf, int buflen, uint32_t datalen) {
+     //TODO: there can be multiple Handshakes in a single TLS record??
+
+     if (buflen < 4) {
+          return 0;
+     }
+     uint8_t htype = buf[0];
+     //24 bits
+     dprint("handshake len bytes %d %d %d", buf[1], buf[2], buf[3]);
+     uint32_t len = (buf[1] << 16) + (buf[2] << 8) + buf[3];
+
+     dprint("handshake len %d, buflen %d, datalen %d", len, buflen,
+                datalen);
+     if (len > (datalen-4)) {
+          tuple_add_member_label(parenttuple, tdata, proc->label_encrypted);
+          if (buflen > 4) {
+               tuple_member_create_dep_binary(tdata, dep, proc->label_buffer,
+                                              (char*)buf + 4, buflen - 4);
+          }
+          return 0;
+     }
+     //check if valid type
+     switch(htype) {
+     case HS_HELLOREQUEST:
+          tuple_add_member_label(parenttuple, tdata, proc->label_hellorequest);
+          break;
+     case HS_CERTIFICATE:
+          tuple_add_member_label(parenttuple, tdata, proc->label_certificate);
+          break;
+     case HS_CERTREQUEST:
+          tuple_add_member_label(parenttuple, tdata, proc->label_certrequest);
+          break;
+     case HS_CERTVERIFY:
+          tuple_add_member_label(parenttuple, tdata, proc->label_certverify);
+          break;
+     case HS_FINISHED:
+          tuple_add_member_label(parenttuple, tdata, proc->label_finished);
+          break;
+     case HS_SERVERDONE:
+          tuple_add_member_label(parenttuple, tdata, proc->label_serverdone);
+          break;
+     case HS_SERVERKEY:
+          tuple_add_member_label(parenttuple, tdata, proc->label_serverkey);
+          break;
+     case HS_CLIENTKEY:
+          tuple_add_member_label(parenttuple, tdata, proc->label_clientkey);
+          break;
+     case HS_SERVERHELLO:
+          tuple_add_member_label(parenttuple, tdata, proc->label_serverhello);
+          parse_serverhello(proc, tdata, dep, buf + 4, buflen - 4);
+          break;
+     case HS_CLIENTHELLO:
+          tuple_add_member_label(parenttuple, tdata, proc->label_clienthello);
+          parse_clienthello(proc, tdata, dep, buf + 4, buflen - 4);
+          break;
+
+     default:
+          return 0;
+     }
+
+     if (buflen > 4) { 
+          switch(htype) {
+          case HS_HELLOREQUEST:
+          case HS_CERTREQUEST:
+          case HS_CERTVERIFY:
+          case HS_CERTIFICATE:
+          case HS_FINISHED:
+          case HS_SERVERDONE:
+          case HS_SERVERKEY:
+          case HS_CLIENTKEY:
+          //case HS_SERVERHELLO:
+               tuple_member_create_dep_binary(tdata, dep, proc->label_buffer,
+                                              (char*)buf + 4, buflen - 4);
+               break;
+          }
+     }
+
+     return 1;
+}
+/*
+typedef struct _tls_rec_t {
+     uint8_t ctype;
+     uint8_t major;
+     uint8_t minor;
+     uint16_t len;
+} tls_rec_t; 
+*/
+
+#define TLS_RECHDR (5)
+#define TLS_CHANGECIPHER 20
+#define TLS_ALERT 21
+#define TLS_HANDSHAKE 22
+#define TLS_APPDATA 23
+static int decode_tls(proc_instance_t * proc,
+                             wsdata_t * tdata, wsdata_t * dep,
+                              uint8_t * buf, int buflen) {
+
+     if (buflen < TLS_RECHDR) {
+          return 0; // not TLS
+     }
+
+     uint8_t ctype = buf[0];
+     uint8_t major = buf[1];
+     uint8_t minor = buf[2];
+     uint16_t rlen = (buf[3]<<8) + buf[4];
+
+     dprint("buf %d, rec %d -- after", buflen, rlen);
+
+     switch(ctype) {
+     case TLS_CHANGECIPHER:  
+     case TLS_ALERT:
+     case TLS_HANDSHAKE:
+     case TLS_APPDATA:
+          break;
+     default:
+          //not valid TLS..
+          return 0;
+     }
+
+     if (major != 3) {
+          return 0;
+     }
+     if (minor > 4) {
+          return 0;
+     }
+
+     if (!wsdata_check_label(tdata, proc->label_tls)) {
+          wsdata_add_label(tdata, proc->label_tls);
+     }
+
+     uint8_t * next = buf + TLS_RECHDR;
+     int nextlen;
+
+     uint8_t * remainder = NULL;
+     int remainlen = 0;
+     dprint("buflen %d, rlen: %u", buflen, rlen);
+     if (buflen > ((int) rlen + TLS_RECHDR)) {
+          //we have multiple recs...
+          //TODO
+          nextlen = rlen;
+          remainder = next + rlen;
+          remainlen = buflen - rlen;
+     }
+     else {
+          nextlen = buflen - TLS_RECHDR;
+     }
+
+     wslabel_t * label_ctype = NULL;
+     switch(ctype) {
+     case TLS_CHANGECIPHER:  
+          label_ctype = proc->label_changecipher;
+          break;
+     case TLS_ALERT:
+          label_ctype = proc->label_alert;
+          break;
+     case TLS_HANDSHAKE:
+          label_ctype = proc->label_handshake;
+          break;
+     case TLS_APPDATA:
+          label_ctype = proc->label_appdata;
+          break;
+     }
+
+     wsdata_t * subtuple = tuple_member_create_wsdata(tdata, dtype_tuple,
+                                                      proc->label_tlsrec);
+     tuple_add_member_label(tdata, subtuple, label_ctype);
+     if (!subtuple) {
+          return 0;
+     }
+
+     if (rlen > buflen) {
+          tuple_add_member_label(tdata, subtuple, proc->label_truncated);
+     }
+
+     tuple_member_create_uint16(subtuple, ctype, proc->label_tlstype);
+     tuple_member_create_uint16(subtuple, minor, proc->label_minor);
+     tuple_member_create_uint16(subtuple, rlen, proc->label_tlsreclen);
+
+     switch(ctype) {
+     case TLS_CHANGECIPHER:  
+          //wsdata_add_label(tdata, proc->label_changecipher);
+          dprint("change cipher %d %u", nextlen, rlen);
+          tuple_member_create_dep_binary(subtuple, dep, proc->label_buffer,
+                                         (char*)next, nextlen);
+
+          break;
+     case TLS_ALERT:
+          //wsdata_add_label(tdata, proc->label_alert);
+          dprint("change alert %d %u", nextlen, rlen);
+          tuple_member_create_dep_binary(subtuple, dep, proc->label_buffer,
+                                         (char*)next, nextlen);
+
+          break;
+     case TLS_HANDSHAKE:
+          //wsdata_add_label(tdata, proc->label_handshake);
+          parse_handshake(proc, subtuple, tdata, dep, next, nextlen, rlen);
+          break;
+     case TLS_APPDATA:
+          //wsdata_add_label(tdata, proc->label_appdata);
+          tuple_member_create_dep_binary(subtuple, dep, proc->label_appdatabuf,
+                                         (char*)next, nextlen);
+          dprint("change appdata %d %u", nextlen, rlen);
+          break;
+     }
+
+     //check remainder
+     dprint("remainder len %d", remainlen);
+
+
+     decode_tls(proc, tdata, dep, remainder, remainlen);
+
+     return 1;
+}
+
+//// proc processing function assigned to a specific data type in proc_io_init
+//return 1 if output is available
+// return 2 if not output
+
+// Commented out code represents in-place copy, but uses more memory
+// The current version deflates to a persistent buffer and copies out (more computation)
+
+static int proc_process_label(void * vinstance, wsdata_t* input_data,
+                        ws_doutput_t * dout, int type_index) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+
+     int id;
+     wsdata_t * member;
+     wslabel_t * label;
+     tuple_labelset_iter_t iter;
+     tuple_init_labelset_iter(&iter, input_data,
+                              &proc->lset);
+
+     while (tuple_search_labelset(&iter, &member, &label, &id)) {
+          char * buf;
+          int blen;
+          if (dtype_string_buffer(member, &buf, &blen)) {
+               decode_tls(proc, input_data, member, (uint8_t*)buf, blen);
+          }
+     }
+     
+     ws_set_outdata(input_data, proc->outtype_tuple, dout);
+     proc->outcnt++;
+
+     return 1;
+}
+
+//return 1 if successful
+//return 0 if no..
+int proc_destroy(void * vinstance) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     tool_print("output cnt %" PRIu64, proc->outcnt);
+
+     //free dynamic allocations
+     free(proc);
+
+     return 1;
+}
+


### PR DESCRIPTION
proc_duplicates - Find and label duplicate tuple members
proc_keyarrival - annotates the arrival sequence of each key
proc_keysort - sorts events about a key from lowest to highest numeric value
proc_keytrans - time transitions in value per key
proc_log_keyvalue_parse - decode logs strings that have key=value substrings
proc_onlyafter - pass on events about a key only after detected labels are present
proc_periodic - detect periodic instances per key, assumes DATETIME is available
proc_removenest.c - Creates a new nested tuple, removing specified members
proc_dns.c - decode a binary buffer as a DNS formatted packet
proc_grouppackets.c - merge content buffers on packets with the same session key
proc_pcapin.c - read from pcap source file or interface
proc_tls.c - decode TLS data from a binary buffer.
proc_hmac.c - compute cryptographic hash of specified buffers (sha256, md5, others)

fixed bug in proc_print.c - output hex on binary buffer