### PR TITLE
feature adds for expiration on groupevents and keyadd, added noop and timestamp kids, depricated print2json

### DIFF
--- a/src/include/wsprockeystate.h
+++ b/src/include/wsprockeystate.h
@@ -65,6 +65,7 @@ typedef struct _wsprockeystate_kid_t {
      char * name;
      char * option_str;
      proc_labeloffset_t * labeloffset;
+     int gradual_expire;
 } wsprockeystate_kid_t;
 
 int wsprockeystate_init(int, char *const*, void **, void *, wsprockeystate_kid_t *);

--- a/src/lib/so_loader.c
+++ b/src/lib/so_loader.c
@@ -399,6 +399,11 @@ static int so_load_wsprockeystate(void * sh_file_handle,
 
      module->kskid->name = (char *) dlsym(sh_file_handle,"proc_name");
 
+     int * gradual_expire;
+     gradual_expire = (int*)dlsym(sh_file_handle,"prockeystate_gradual_expire");
+     if (gradual_expire) {
+          module->kskid->gradual_expire = *gradual_expire;
+     }
 
      if (!module->kskid->option_str) {
           module->kskid->option_str = "";

--- a/src/procs/Makefile
+++ b/src/procs/Makefile
@@ -175,6 +175,18 @@ proc_workreceive$(WS_SFX): proc_workreceive.c
 	@echo " not building $@, only built for WS_PARALLEL=1"
 endif
 
+ifdef DEPRECATED
+proc_print2json$(WS_SFX): proc_print2json.c
+	$(SHOWFILE) 
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+	$(INSTALL) $@ $(WS_PROCS_DIR)
+else
+proc_print2json$(WS_SFX): proc_print2json.c
+	@echo " not building $@, deprecated process, set DEPRECATED=1 to build"
+endif
+
+
+
 #********
 #*****
 #********

--- a/src/procs/proc_keyadd.c
+++ b/src/procs/proc_keyadd.c
@@ -36,6 +36,7 @@ SOFTWARE.
 #include "procloader_keystate.h"
 
 int is_prockeystate = 1;
+int prockeystate_gradual_expire = 1;
 
 char proc_version[]     = "1.5";
 char *proc_menus[] = { "Count", NULL };

--- a/src/procs/proc_keyadd.c
+++ b/src/procs/proc_keyadd.c
@@ -133,7 +133,7 @@ static inline void add_scores(proc_instance_t *proc,
                               wsdata_t * tup, key_data_t * kd, 
                               ws_doutput_t * dout,
                               ws_outtype_t * outtype_tuple) {
-     tuple_member_create_uint(tup, kd->cnt, proc->label_cnt);
+     tuple_member_create_uint64(tup, kd->cnt, proc->label_cnt);
      if (proc->do_pct) {
           tuple_member_create_double(tup,
                                      (double)kd->cnt/(double)proc->totalcnt,

--- a/src/procs/proc_keyadd.c
+++ b/src/procs/proc_keyadd.c
@@ -82,7 +82,12 @@ char proc_nonswitch_opts[]    = "LABEL of key to count";
 char *proc_input_types[]    = {"tuple", NULL};
 char *proc_output_types[]    = {"tuple", NULL};
 char *proc_tuple_member_labels[] = {"COUNT", NULL};
-proc_port_t proc_input_ports[] = {{NULL, NULL}};
+proc_port_t proc_input_ports[] =  {
+     {"none","normal operation"},
+     {"EXPIRE","trigger gradual expiration of buffered states"},
+     {NULL, NULL}
+};
+
 char *proc_tuple_conditional_container_labels[] = {NULL};
 
 typedef struct _key_data_t {

--- a/src/procs/proc_noop.c
+++ b/src/procs/proc_noop.c
@@ -1,0 +1,178 @@
+/*
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+ */
+#define PROC_NAME "noop"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "waterslide.h"
+#include "waterslidedata.h"
+#include "datatypes/wsdt_flush.h"
+#include "procloader.h"
+
+char proc_name[]               =  PROC_NAME;
+char proc_version[]            =  "1.5";
+// Use to fix proc_tags: 
+//char *proc_menus[]             =  { "Filters", NULL };
+char *proc_tags[]              =  {"Filters", NULL};
+char *proc_alias[]             =  { NULL };
+char proc_purpose[]            =  "No Operation passthrough";
+char proc_description[] = "A passthrough that performs no operation on data"; 
+
+proc_option_t proc_opts[]      =  {
+     /*  'option character', "long option string", "option argument",
+	 "option description", <allow multiple>, <required>*/
+     {'S',"","",
+     "act as a tuple input source but emit nothing",0,0},
+     //the following must be left as-is to signify the end of the array
+     {' ',"","",
+     "",0,0}
+};
+char proc_nonswitch_opts[]     =  "None";
+char *proc_input_types[]       =  {"any", NULL};
+char *proc_output_types[]      =  {"any", NULL};
+char proc_requires[]           =  "None";
+// Ports: 
+proc_port_t proc_input_ports[] =  {{NULL, NULL}};
+char *proc_tuple_container_labels[] =  {NULL};
+char *proc_tuple_conditional_container_labels[] =  {NULL};
+char *proc_tuple_member_labels[] =  {NULL};
+
+#define LOCAL_MAX_TYPES 25
+
+//function prototypes for local functions
+static int proc_process_meta(void *, wsdata_t*, ws_doutput_t*, int);
+static int proc_source(void *, wsdata_t*, ws_doutput_t*, int);
+
+typedef struct _proc_instance_t {
+     uint64_t meta_process_cnt;
+     uint64_t outcnt;
+     ws_outtype_t * outtype_meta[LOCAL_MAX_TYPES];
+     ws_outtype_t * outtype_tuple;
+     int do_source;
+} proc_instance_t;
+
+
+static int proc_cmd_options(int argc, char ** argv, 
+                            proc_instance_t * proc, void * type_table) {
+     int op;
+
+     while ((op = getopt(argc, argv, "S")) != EOF) {
+          switch (op) {
+          case 'S':
+               proc->do_source = 1;
+               break;
+          default:
+               return 0;
+          }
+     }
+     return 1;
+}
+
+// the following is a function to take in command arguments and initalize
+// this processor's instance..
+//  also register as a source here..
+// return 1 if ok
+// return 0 if fail
+int proc_init(wskid_t * kid, int argc, char ** argv, void ** vinstance, ws_sourcev_t * sv,
+              void * type_table) {
+     
+     //allocate proc instance of this processor
+     proc_instance_t * proc =
+          (proc_instance_t*)calloc(1,sizeof(proc_instance_t));
+     *vinstance = proc;
+
+
+     //read in command options
+     if (!proc_cmd_options(argc, argv, proc, type_table)) {
+          return 0;
+     }
+
+     if (proc->do_source) {
+          proc->outtype_tuple = ws_register_source(dtype_tuple, proc_source, sv);
+     }
+     
+     return 1; 
+}
+
+// this function needs to decide on processing function based on datatype
+// given.. also set output types as needed (unless a sink)
+//return 1 if ok
+// return 0 if problem
+proc_process_t proc_input_set(void * vinstance, wsdatatype_t * meta_type,
+                              wslabel_t * port,
+                              ws_outlist_t* olist, int type_index,
+                              void * type_table) {
+     proc_instance_t * proc = (proc_instance_t *)vinstance;
+
+     //register output..
+     // pass the input type to the output..
+     if (type_index >= LOCAL_MAX_TYPES) {
+          return NULL;
+     }
+
+     if (wsdatatype_match(type_table, meta_type, "FLUSH_TYPE")) {
+          return NULL;
+     }
+
+     //handle any datatype passed in
+     proc->outtype_meta[type_index] = ws_add_outtype(olist, meta_type, NULL);
+
+     // we are happy.. now set the processor function
+     return proc_process_meta; // a function pointer
+}
+
+static int proc_process_meta(void * vinstance, wsdata_t* input_data,
+                        ws_doutput_t * dout, int type_index) {
+
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+
+     proc->meta_process_cnt++;
+
+     //pass through
+     ws_set_outdata(input_data, proc->outtype_meta[type_index], dout);
+     proc->outcnt++;
+     return 1;
+}
+
+//return 0 = no data left
+static int proc_source(void * vinstance, wsdata_t* input_data,
+                       ws_doutput_t * dout, int type_index) {
+
+     //return no data as source
+     return 0;
+}
+
+
+//return 1 if successful
+//return 0 if no..
+int proc_destroy(void * vinstance) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     tool_print("meta_proc cnt %" PRIu64, proc->meta_process_cnt);
+     tool_print("output cnt %" PRIu64, proc->outcnt);
+
+     //free dynamic allocations
+     free(proc);
+
+     return 1;
+}
+

--- a/src/procs/proc_timestamp.c
+++ b/src/procs/proc_timestamp.c
@@ -1,0 +1,198 @@
+/* 
+proc_timestamp.c - add a timestamp (current GMT time) to a tuple
+
+Copyright 2019 Morgan Stanley
+
+THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF YOU MAY OBTAIN A COPY OF
+THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
+
+THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY
+WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY
+EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY
+OTHER REQUIRED LICENSE TERMS
+*/
+
+#define PROC_NAME "timestamp"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <time.h>
+#include "waterslide.h"
+#include "waterslidedata.h"
+#include "procloader.h"
+#include "sysutil.h"
+#include "datatypes/wsdt_tuple.h"
+#include "wstypes.h"
+
+#define LOCAL_MAX_TYPES 50
+
+char proc_name[]               =  PROC_NAME;
+char proc_version[]            =  "1.5";
+char *proc_tags[]              =  { "Source", NULL };
+char *proc_alias[]             =  { "addtime", "time_add", "datetime", "add_time", "timeadd",  NULL };
+char proc_purpose[]            =  "add current timestamp to tuple";
+proc_option_t proc_opts[]      =  {
+     /*  'option character', "long option string", "option argument",
+	 "option description", <allow multiple>, <required>*/
+     //the following must be left as-is to signify the end of the array
+     {'U',"","",
+     "output uint64 as milli seconds from 1970",0,0},
+     {'o',"","sec",
+     "offset from wall clock time",0,0},
+     {'L',"","label",
+     "label of timestamp (default: DATETIME)",0,0},
+     {' ',"","",
+     "",0,0}
+};
+char proc_nonswitch_opts[]     =  "";
+char *proc_input_types[]       =  { "tuple", NULL };
+// (Potential) Output types: flush, tuple, meta[LOCAL_MAX_TYPES]
+char *proc_output_types[]      =  { "tuple", NULL };
+char proc_requires[]           =  "";
+// Ports: 
+proc_port_t proc_input_ports[] =  {{NULL, NULL}};
+char *proc_tuple_container_labels[] =  {NULL};
+char *proc_tuple_conditional_container_labels[] =  {NULL};
+char *proc_tuple_member_labels[] =  {NULL};
+char *proc_synopsis[]          =  { "add_time", NULL };
+
+
+//function prototypes for local functions
+static int proc_tuple(void *, wsdata_t*, ws_doutput_t*, int);
+
+typedef struct _proc_instance_t {
+     uint64_t meta_process_cnt;
+     uint64_t outcnt;
+
+     wslabel_t * label_datetime;
+     ws_outtype_t * outtype_tuple;
+     time_t offset;
+     int as_uint64;
+} proc_instance_t;
+
+static int proc_cmd_options(int argc, char ** argv, 
+                             proc_instance_t * proc, void * type_table) {
+
+     int op;
+
+     while ((op = getopt(argc, argv, "uUo:O:L:")) != EOF) {
+          switch (op) {
+          case 'u':
+          case 'U':
+               proc->as_uint64 = 1;
+               break;
+          case 'o':
+          case 'O':
+               proc->offset = (time_t)atoi(optarg);
+               tool_print("using offset %u seconds", (uint32_t)proc->offset);
+               break;
+          case 'L':
+               proc->label_datetime = wssearch_label(type_table, optarg);
+               break;
+          default:
+               return 0;
+          }
+     }
+     return 1;
+}
+
+// the following is a function to take in command arguments and initalize
+// this processor's instance..
+//  also register as a source here..
+// return 1 if ok
+// return 0 if fail
+int proc_init(wskid_t * kid, int argc, char ** argv, void ** vinstance, ws_sourcev_t * sv,
+              void * type_table) {
+     
+     //allocate proc instance of this processor
+     proc_instance_t * proc =
+          (proc_instance_t*)calloc(1,sizeof(proc_instance_t));
+     *vinstance = proc;
+
+
+     //read in command options
+     if (!proc_cmd_options(argc, argv, proc, type_table)) {
+          return 0;
+     }
+
+     if (!proc->label_datetime) {
+          if (proc->as_uint64) {
+               proc->label_datetime = wssearch_label(type_table, "MSEC");
+          }
+          else  {
+               proc->label_datetime = wssearch_label(type_table, "DATETIME");
+          }
+     }
+     return 1; 
+}
+
+
+proc_process_t proc_input_set(void * vinstance, wsdatatype_t * input_type,
+                              wslabel_t * port,
+                              ws_outlist_t* olist, int type_index,
+                              void * type_table) {
+
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+
+     if (!proc->outtype_tuple) {
+          proc->outtype_tuple = ws_add_outtype(olist, dtype_tuple, NULL);
+     }
+     if (input_type == dtype_tuple) {
+          return proc_tuple;
+     }
+     return NULL;
+}
+
+
+static int proc_tuple(void * vinstance, wsdata_t* input_data,
+                        ws_doutput_t * dout, int type_index) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+
+     proc->meta_process_cnt++;
+
+     struct timeval current;
+     gettimeofday(&current, NULL);
+
+     if (proc->as_uint64) {
+          uint64_t utime = ((current.tv_sec + proc->offset) * 1000) +
+               (current.tv_usec / 1000);
+          tuple_member_create_uint64(input_data, utime, proc->label_datetime);
+     }
+     else {
+          wsdt_ts_t ts;
+          ts.sec = current.tv_sec + proc->offset;
+          ts.usec = current.tv_usec;
+
+          tuple_member_create_ts(input_data, ts, proc->label_datetime);
+     }
+
+     proc->outcnt++;
+     ws_set_outdata(input_data, proc->outtype_tuple, dout);
+
+     return 1;
+}
+
+//return 1 if successful
+//return 0 if no..
+int proc_destroy(void * vinstance) {
+     proc_instance_t * proc = (proc_instance_t*)vinstance;
+     tool_print("meta_proc cnt %" PRIu64, proc->meta_process_cnt);
+     tool_print("output cnt %" PRIu64, proc->outcnt);
+
+     //free dynamic allocations
+     free(proc);
+
+     return 1;
+}
+


### PR DESCRIPTION
bugfix for keyadd - output uint64 instead of truncated uint32
added optional gradual flush for groupevents
added gradual expiration to keyadd - triggered by EXPIRE port
added new kids:
   noop - as a passthrough placeholder used in complex graphs
   timestamp - to add a current timestamp to a tuple